### PR TITLE
Add calendar entries in a separate thread to prevent the GUI from blocking

### DIFF
--- a/src/fahrplan.h
+++ b/src/fahrplan.h
@@ -58,7 +58,7 @@ class Fahrplan : public QObject
         void setParser(int index);
         void storeSettingsValue(QString key, QString value);
         QString getSettingsValue(QString key, QString defaultValue);
-        bool addJourneyDetailResultToCalendar(JourneyDetailResultList *result);
+        void addJourneyDetailResultToCalendar(JourneyDetailResultList *result);
 
     signals:
         void parserStationsResult(StationsResultList *result);
@@ -68,6 +68,7 @@ class Fahrplan : public QObject
         void parserErrorOccured(QString msg);
         void parserChanged(QString name, int index);
         void favoritesChanged(QStringList favorites);
+        void calendarEntryAdded(JourneyDetailResultList *result, bool success);
 
     private slots:
         void onStationsResult(StationsResultList *result);
@@ -82,6 +83,19 @@ class Fahrplan : public QObject
         static FahrplanBackendManager *m_parser_manager;
         static FahrplanFavoritesManager *m_favorites_manager;
         QSettings *settings;
+};
+
+class CalendarAdditionTask : public QObject {
+    Q_OBJECT
+public:
+    explicit CalendarAdditionTask(JourneyDetailResultList *result, QObject *parent = 0);
+    virtual ~CalendarAdditionTask();
+public slots:
+    void addToCalendar();
+signals:
+    void additionComplete(JourneyDetailResultList *result, bool success);
+private:
+    JourneyDetailResultList * const m_result;
 };
 
 #endif // FAHRPLAN_H

--- a/src/gui/harmattan/JourneyDetailsResultsPage.qml
+++ b/src/gui/harmattan/JourneyDetailsResultsPage.qml
@@ -302,6 +302,7 @@ Page {
 
     FahrplanBackend {
         id: fahrplanBackend
+
         onParserJourneyDetailsResult: {
             currentResult = result;
             console.log("Got detail results");
@@ -421,15 +422,32 @@ Page {
 
         ToolIcon {
             id : calendarIcon;
-            iconId: "toolbar-list"
+            iconId: enabled ? "toolbar-list" : ""
             visible: !searchIndicator.visible
+
             onClicked: {
-                if (fahrplanBackend.addJourneyDetailResultToCalendar(currentResult)) {
-                    banner.text = "Journey has been added to your calendar.";
-                } else {
-                    banner.text = "Failed to add Journey to your calendar!";
-                }
-                banner.show();
+                calendarIcon.enabled = false
+                fahrplanBackend.addJourneyDetailResultToCalendar(currentResult);
+            }
+
+            Connections {
+                target: fahrplanBackend
+                onCalendarEntryAdded: {
+                                          if (success)
+                                              banner.text = "Journey has been added to your calendar.";
+                                          else
+                                              banner.text = "Failed to add Journey to your calendar!";
+
+                                          banner.show();
+                                          calendarIcon.enabled = true
+                                      }
+            }
+
+            BusyIndicator {
+                visible: !calendarIcon.enabled
+                running: true
+                style: BusyIndicatorStyle { size: "small" }
+                anchors.centerIn: parent
             }
         }
     }


### PR DESCRIPTION
Currently the calendar entries are added from the GUI thread and therefore the GUI becomes unresponsive while the addition is taking place. I have fixed this issue by performing the addition in a new thread and adding a busy indicator in-place to indicate that the entry is being added.
