### PR TITLE
parseStationsByName() already implemented in ParserHafasXml

### DIFF
--- a/src/parser/parser_hafasxml.h
+++ b/src/parser/parser_hafasxml.h
@@ -115,11 +115,11 @@ protected:
 
     JourneyResultList *lastJourneyResultList;
     QList<JourneyDetailResultList*> journeyDetailInlineData;
-    StationsResultList* internalParseStationsByName(const QString &data);
 
 private:
     void parseSearchJourneyPart1(QNetworkReply *networkReply);
     void parseSearchJourneyPart2(QNetworkReply *networkReply);
+    StationsResultList* internalParseStationsByName(const QString &data);
     ParserHafasXmlExternalIds parseExternalIds(QByteArray data);
 
     ParserHafasXmlGetTimeTableForStationRequestData getTimeTableForStationRequestData;

--- a/src/parser/parser_xmlsbbch.cpp
+++ b/src/parser/parser_xmlsbbch.cpp
@@ -31,13 +31,6 @@ ParserXmlSbbCh::ParserXmlSbbCh(QObject *parent)
      hafasHeader.ver = "2.3";
 }
 
-void ParserXmlSbbCh::parseStationsByName(QNetworkReply *networkReply)
-{
-    QString data = QString::fromUtf8(networkReply->readAll());
-    StationsResultList *result = internalParseStationsByName(data);
-    emit stationsResult(result);
-}
-
 QString ParserXmlSbbCh::getTrainRestrictionsCodes(int trainrestrictions)
 {
     QString trainrestr = "1111111111111111";

--- a/src/parser/parser_xmlsbbch.h
+++ b/src/parser/parser_xmlsbbch.h
@@ -33,7 +33,6 @@ public:
     QString name() { return "sbb.ch"; }
 
 protected:
-    void parseStationsByName(QNetworkReply *networkReply);
     QStringList getTrainRestrictions();
     QString getTrainRestrictionsCodes(int trainrestrictions);
 };


### PR DESCRIPTION
The reimplementation in ParserXmlSbbCh contains a verbatim copy of the original method in ParserHafasXml. Therefore, the reimplementation isn't needed.
