### PR TITLE
Localized time display.

### DIFF
--- a/src/gui/desktop-test/mainwindow.cpp
+++ b/src/gui/desktop-test/mainwindow.cpp
@@ -126,7 +126,7 @@ void MainWindow::timeTableResult(TimeTableResultList *result)
     for (int i=0; i < result->itemcount(); i++) {
         TimeTableResultItem *item = result->getItem(i);
         ui->findStationResults->append(item->stationName());
-        ui->findStationResults->append(item->time().toString("hh:mm"));
+        ui->findStationResults->append(item->time().toString(tr("hh:mm")));
         ui->findStationResults->append(item->destinationName());
         ui->findStationResults->append(item->trainType());
         ui->findStationResults->append(item->platform());

--- a/src/gui/harmattan/JourneyDetailsResultsPage.qml
+++ b/src/gui/harmattan/JourneyDetailsResultsPage.qml
@@ -325,8 +325,8 @@ Page {
                     arrivalDate = "";
                 }
 
-                lbljourneyDate.text = departureDate + " " + Qt.formatTime(result.departureDateTime,"hh:mm") + " - " +
-                        arrivalDate + " " + Qt.formatTime(result.arrivalDateTime,"hh:mm");
+                lbljourneyDate.text = departureDate + " " + Qt.formatTime(result.departureDateTime, qsTr("hh:mm")) + " - " +
+                        arrivalDate + " " + Qt.formatTime(result.arrivalDateTime, qsTr("hh:mm"));
 
                 lbljourneyDuration.text = qsTr("Dur.: %1").arg(result.duration);
 
@@ -352,7 +352,7 @@ Page {
                                                             "stationName" : item.departureStation,
                                                             "stationInfo" : item.departureInfo,
                                                             "arrivalTime" : "",
-                                                            "departureTime" : Qt.formatTime(item.departureDateTime,"hh:mm"),
+                                                            "departureTime" : Qt.formatTime(item.departureDateTime, qsTr("hh:mm")),
                                                             "isStation" : true,
                                                             "isTrain" : true
 
@@ -368,7 +368,7 @@ Page {
                                                             "trainName" : "",
                                                             "stationName" : item.arrivalStation,
                                                             "stationInfo" :  item.arrivalInfo,
-                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime,"hh:mm"),
+                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime, qsTr("hh:mm")),
                                                             "departureTime" : "",
                                                             "isStation" : true,
                                                             "isTrain" : false
@@ -393,8 +393,8 @@ Page {
                                                             "trainName" :  nextItem.train + " " + nextItem.info,
                                                             "stationName" : item.arrivalStation,
                                                             "stationInfo" : stationInfo,
-                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime,"hh:mm"),
-                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime,"hh:mm"),
+                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime, qsTr("hh:mm")),
+                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime, qsTr("hh:mm")),
                                                             "isStation" : true,
                                                             "isTrain" : true
 

--- a/src/gui/harmattan/MainPage.qml
+++ b/src/gui/harmattan/MainPage.qml
@@ -54,7 +54,7 @@ Page {
         timePicker.hour = d.getHours();
         timePicker.minute = d.getMinutes();
         timePicker.second = d.getSeconds();
-        timePickerButton.subTitleText = Qt.formatTime(d, "hh:mm");
+        timePickerButton.subTitleText = Qt.formatTime(d, qsTr("hh:mm"));
         datePicker.year = d.getFullYear();
         datePicker.month = d.getMonth() + 1; // month is 0 based in Date()
         datePicker.day = d.getDate();
@@ -475,10 +475,16 @@ Page {
         acceptButtonText: qsTr("Ok")
         rejectButtonText: qsTr("Cancel")
         fields: DateTime.Hours | DateTime.Minutes
-        hourMode: DateTime.TwentyFourHours // FIXME should set through i18n
+        hourMode: {
+            if (qsTr("hh:mm").toLowerCase().indexOf("ap") < 0)
+                return DateTime.TwentyFourHours;
+            else
+                return DateTime.TwelveHours;
+        }
+
         onAccepted: {
             var selTime = new Date(1970, 2, 1, timePicker.hour, timePicker.minute, timePicker.second);
-            timePickerButton.subTitleText = Qt.formatTime(selTime, "hh:mm");
+            timePickerButton.subTitleText = Qt.formatTime(selTime, qsTr("hh:mm"));
         }
         Component.onCompleted: {
             //setToday sets both the time and the date to today, so only needed here (seems to work)

--- a/src/gui/harmattan/TimeTableResultsPage.qml
+++ b/src/gui/harmattan/TimeTableResultsPage.qml
@@ -213,7 +213,7 @@ Page {
                 }
 
                 timetableResultModel.append({
-                    "time": Qt.formatTime( item.time,"hh:mm"),
+                    "time": Qt.formatTime( item.time, qsTr("hh:mm")),
                     "trainType": item.trainType,
                     "destination": dirlabel,
                     "stationplatform": stationplatform,

--- a/src/gui/symbian/JourneyDetailsResultsPage.qml
+++ b/src/gui/symbian/JourneyDetailsResultsPage.qml
@@ -351,8 +351,8 @@ Page {
                     arrivalDate = "";
                 }
 
-                lbljourneyDate.text = departureDate + " " + Qt.formatTime(result.departureDateTime,"hh:mm") + " - " +
-                        arrivalDate + " " + Qt.formatTime(result.arrivalDateTime,"hh:mm");
+                lbljourneyDate.text = departureDate + " " + Qt.formatTime(result.departureDateTime, qsTr("hh:mm")) + " - " +
+                        arrivalDate + " " + Qt.formatTime(result.arrivalDateTime, qsTr("hh:mm"));
 
                 lbljourneyDuration.text = qsTr("Dur.: %1").arg(result.duration);
 
@@ -378,7 +378,7 @@ Page {
                                                             "stationName" : item.departureStation,
                                                             "stationInfo" : item.departureInfo,
                                                             "arrivalTime" : "",
-                                                            "departureTime" : Qt.formatTime(item.departureDateTime,"hh:mm"),
+                                                            "departureTime" : Qt.formatTime(item.departureDateTime, qsTr("hh:mm")),
                                                             "isStation" : true,
                                                             "isTrain" : true
 
@@ -394,7 +394,7 @@ Page {
                                                             "trainName" : "",
                                                             "stationName" : item.arrivalStation,
                                                             "stationInfo" :  item.arrivalInfo,
-                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime,"hh:mm"),
+                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime, qsTr("hh:mm")),
                                                             "departureTime" : "",
                                                             "isStation" : true,
                                                             "isTrain" : false
@@ -419,8 +419,8 @@ Page {
                                                             "trainName" :  nextItem.train + " " + nextItem.info,
                                                             "stationName" : item.arrivalStation,
                                                             "stationInfo" : stationInfo,
-                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime,"hh:mm"),
-                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime,"hh:mm"),
+                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime, qsTr("hh:mm")),
+                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime, qsTr("hh:mm")),
                                                             "isStation" : true,
                                                             "isTrain" : true
 

--- a/src/gui/symbian/MainPage.qml
+++ b/src/gui/symbian/MainPage.qml
@@ -55,7 +55,7 @@ Page {
         timePicker.hour = d.getHours();
         timePicker.minute = d.getMinutes();
         timePicker.second = d.getSeconds();
-        timePickerButton.subTitleText = Qt.formatTime(d, "hh:mm");
+        timePickerButton.subTitleText = Qt.formatTime(d, qsTr("hh:mm"));
         datePicker.year = d.getFullYear();
         datePicker.month = d.getMonth() + 1; // month is 0 based in Date()
         datePicker.day = d.getDate();
@@ -500,11 +500,16 @@ Page {
         acceptButtonText: qsTr("Ok")
         rejectButtonText: qsTr("Cancel")
         fields: DateTime.Hours | DateTime.Minutes
-        hourMode: DateTime.TwentyFourHours // FIXME should set through i18n
+        hourMode: {
+            if (qsTr("hh:mm").toLowerCase().indexOf("ap") < 0)
+                return DateTime.TwentyFourHours;
+            else
+                return DateTime.TwelveHours;
+        }
         platformInverted: appWindow.platformInverted
         onAccepted: {
             var selTime = new Date(1970, 2, 1, timePicker.hour, timePicker.minute, timePicker.second);
-            timePickerButton.subTitleText = Qt.formatTime(selTime, "hh:mm");
+            timePickerButton.subTitleText = Qt.formatTime(selTime, qsTr("hh:mm"));
         }
         Component.onCompleted: {
             //setToday sets both the time and the date to today, so only needed here (seems to work)

--- a/src/gui/symbian/TimeTableResultsPage.qml
+++ b/src/gui/symbian/TimeTableResultsPage.qml
@@ -212,7 +212,7 @@ Page {
                 }
 
                 timetableResultModel.append({
-                    "time": Qt.formatTime( item.time,"hh:mm"),
+                    "time": Qt.formatTime( item.time, qsTr("hh:mm")),
                     "trainType": item.trainType,
                     "destination": dirlabel,
                     "stationplatform": stationplatform,

--- a/src/parser/parser_131500comau.cpp
+++ b/src/parser/parser_131500comau.cpp
@@ -326,8 +326,8 @@ void Parser131500ComAu::parseSearchJourney(QNetworkReply *networkReply)
         item->setTransfers(QString::number(changes));
         item->setDuration(durationStr);
         item->setTrainType(trains.join(", "));
-        item->setDepartureTime(QTime::fromString(departResult[i].trimmed(), "h:map").toString("hh:mm"));
-        item->setArrivalTime(QTime::fromString(arriveResult[i].trimmed(), "h:map").toString("hh:mm"));
+        item->setDepartureTime(QTime::fromString(departResult[i].trimmed(), "h:map").toString(tr("hh:mm")));
+        item->setArrivalTime(QTime::fromString(arriveResult[i].trimmed(), "h:map").toString(tr("hh:mm")));
         item->setInternalData1(detailsResult[i]);
 
         lastJourneyResultList->appendItem(item);

--- a/src/parser/parser_hafasbinary.cpp
+++ b/src/parser/parser_hafasbinary.cpp
@@ -428,8 +428,8 @@ void ParserHafasBinary::parseSearchJourney(QNetworkReply *networkReply)
                 item->setDuration(formatDuration(durationTime));
                 item->setMiscInfo("");
                 item->setTrainType(lineNames.join(", ").trimmed());
-                item->setDepartureTime(inlineResults->getItem(0)->departureDateTime().time().toString("hh:mm"));
-                item->setArrivalTime(inlineResults->getItem(inlineResults->itemcount() - 1)->arrivalDateTime().time().toString("hh:mm"));
+                item->setDepartureTime(inlineResults->getItem(0)->departureDateTime().time().toString(tr("hh:mm")));
+                item->setArrivalTime(inlineResults->getItem(inlineResults->itemcount() - 1)->arrivalDateTime().time().toString(tr("hh:mm")));
                 journeyResultsByArrivalMap.insert(inlineResults->getItem(inlineResults->itemcount() - 1)->arrivalDateTime(), item);
             }
         }
@@ -445,7 +445,7 @@ void ParserHafasBinary::parseSearchJourney(QNetworkReply *networkReply)
 
         emit journeyResult(lastJourneyResultList);
     } else if (errorCode == 8) {
-        emit errorOccured(tr("Sorry one station name is to ambiguous"));
+        emit errorOccured(tr("Sorry one station name is too ambiguous"));
     } else {
         emit errorOccured(tr("An error ocurred with the backend"));
     }

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -486,8 +486,8 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
             if (journeyStart.time() > journeyEnd.time())
                 journeyEnd.addDays(1);
             jritem->setDate(journeyStart.date());
-            jritem->setDepartureTime(journeyStart.time().toString("hh:mm"));
-            jritem->setArrivalTime(journeyEnd.time().toString("hh:mm"));
+            jritem->setDepartureTime(journeyStart.time().toString(tr("hh:mm")));
+            jritem->setArrivalTime(journeyEnd.time().toString(tr("hh:mm")));
             int diffTime = journeyStart.secsTo(journeyEnd);
             if (diffTime < 0) diffTime += 86400;
             jritem->setDuration(tr("%1:%2").arg(diffTime / 3600).arg(QString::number(diffTime / 60 % 60), 2, '0'));


### PR DESCRIPTION
Made time localizable by making "hh:mm" string translatable.

Also, however seems a bit hacky to me, but that's a best solution that came to my mind, TimePickerDialog.hourMode is set based on localized "hh:mm" string: if it contains "ap" than it will be set to DateTime.TwelveHours mode, otherwise - to DateTime.TwentyFourHours mode.
