### PR TITLE
Remove GPS opt-out option.

### DIFF
--- a/src/gui/harmattan/pages/MainPage.qml
+++ b/src/gui/harmattan/pages/MainPage.qml
@@ -500,17 +500,6 @@ Page {
         }
     }
 
-    QueryDialog {
-            id: firstStartDialog;
-            message: qsTr("Hello<br/>" +
-                "Sorry about this dialog, but the new Nokia store regulations require it.<br/><br/>" +
-                "Please read the Privacy Policy of fahrplan. (available on the about page)<br/><br/>" +
-                "If you want, you can also disable the gps features of fahrplan via the about menu."
-            )
-            acceptButtonText: qsTr("Ok")
-    }
-
-
     ContextMenu {
         id: timeTableSelectContextMenu
         MenuLayout {
@@ -653,17 +642,6 @@ Page {
     Component {
         id: settingsPage
         SettingsPage {}
-    }
-
-    onStatusChanged: {
-        switch (status) {
-            case PageStatus.Active:
-                if (fahrplanBackend.getSettingsValue("firstStart", "true") == "true") {
-                    firstStartDialog.open();
-                    fahrplanBackend.storeSettingsValue("firstStart", "false");
-                }
-                break;
-        }
     }
 
     Component.onCompleted: {

--- a/src/gui/harmattan/pages/SettingsPage.qml
+++ b/src/gui/harmattan/pages/SettingsPage.qml
@@ -84,17 +84,6 @@ Page {
                 width: parent.width
 
                 SwitchLabel {
-                    title: qsTr("GPS location support")
-                    subtitle: checked ? qsTr("Opted-in") : qsTr("Opted-out")
-
-                    onCheckedChanged: {
-                        fahrplanBackend.storeSettingsValue("enableGps", checked);
-                    }
-                    Component.onCompleted: {
-                        checked = fahrplanBackend.getSettingsValue("enableGps", true);
-                    }
-                }
-                SwitchLabel {
                     title: qsTr("Compact calendar entries")
                     subtitle: qsTr("Use shorter text format in the calendar event description")
 

--- a/src/gui/harmattan/pages/StationSelectPage.qml
+++ b/src/gui/harmattan/pages/StationSelectPage.qml
@@ -203,7 +203,7 @@ Page {
     onStatusChanged: {
         switch (status) {
             case PageStatus.Activating:
-                gpsButton.visible = fahrplanBackend.parser.supportsGps() && (fahrplanBackend.getSettingsValue("enableGps", "true") == "true");
+                gpsButton.visible = fahrplanBackend.parser.supportsGps();
                 break;
         }
     }

--- a/src/gui/symbian/pages/MainPage.qml
+++ b/src/gui/symbian/pages/MainPage.qml
@@ -537,16 +537,6 @@ Page {
         }
     }
 
-    QueryDialog {
-            id: firstStartDialog;
-            message: qsTr("Hello<br/>" +
-                "Sorry about this dialog, but the new Nokia store regulations require it.<br/><br/>" +
-                "Please read the Privacy Policy of fahrplan. (available on the about page)<br/><br/>" +
-                "If you want, you can also disable the gps features of fahrplan via the about menu."
-            )
-            acceptButtonText: qsTr("Ok")
-    }
-
     ContextMenu {
         id: timeTableSelectContextMenu
         platformInverted: appWindow.platformInverted
@@ -691,10 +681,6 @@ Page {
         interval: 500
         onTriggered: {
             exitIcon.enabled = true
-            if (fahrplanBackend.getSettingsValue("firstStart", "true") == "true") {
-                firstStartDialog.open();
-                fahrplanBackend.storeSettingsValue("firstStart", "false");
-            }
         }
     }
 

--- a/src/gui/symbian/pages/SettingsPage.qml
+++ b/src/gui/symbian/pages/SettingsPage.qml
@@ -84,19 +84,6 @@ Page {
                 width: parent.width
 
                 SwitchLabel {
-                    title: qsTr("GPS location support")
-                    subtitle: checked ? qsTr("Opted-in") : qsTr("Opted-out")
-                    visible: appWindow.showStatusBar
-                    platformInverted: appWindow.platformInverted
-
-                    onCheckedChanged: {
-                        fahrplanBackend.storeSettingsValue("enableGps", checked);
-                    }
-                    Component.onCompleted: {
-                        checked = fahrplanBackend.getSettingsValue("enableGps", true);
-                    }
-                }
-                SwitchLabel {
                     title: qsTr("Compact calendar entries")
                     subtitle: qsTr("Use shorter text format in the calendar event description")
                     platformInverted: appWindow.platformInverted

--- a/src/gui/symbian/pages/StationSelectPage.qml
+++ b/src/gui/symbian/pages/StationSelectPage.qml
@@ -210,7 +210,7 @@ Page {
     onStatusChanged: {
         switch (status) {
             case PageStatus.Activating:
-                gpsButton.visible = fahrplanBackend.parser.supportsGps() && (fahrplanBackend.getSettingsValue("enableGps", "true") == "true");
+                gpsButton.visible = fahrplanBackend.parser.supportsGps();
                 break;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,9 +145,6 @@ int main(int argc, char *argv[])
 
             QSettings *settings = new QSettings(FAHRPLAN_SETTINGS_NAMESPACE, "fahrplan2");
 
-            // HACK: Don't show Nokia privacy dialog on BlackBerry
-            settings->setValue("firstStart", "false");
-
             // Check if GPS Location permission is set
             // and geolocation services are enabled.
             int res = geolocation_request_events(0);


### PR DESCRIPTION
It was added only because it was required by the Nokis Store guidlines. As
Nokia Store doesn't accept MeeGo and Symbian apps anymore, it can now be
safely removed.
