### PR TITLE
Changed way detail-page is rendered

### DIFF
--- a/src/gui/harmattan/pages/JourneyDetailsResultsPage.qml
+++ b/src/gui/harmattan/pages/JourneyDetailsResultsPage.qml
@@ -178,6 +178,17 @@ Page {
                         nextItem = result.getItem(i+1);
                     }
 
+                    /*
+                    console.log("-------------" + i);
+                    console.log(item.departureStation);
+                    console.log(item.train);
+                    console.log(item.arrivalStation);
+                    if (nextItem) {
+                        console.log(nextItem.departureStation);
+                        console.log(nextItem.train);
+                        console.log(nextItem.arrivalStation);
+                    }
+                    */
 
                     var isStart = (i == 0);
                     var isStop = (i == result.count -1);
@@ -193,16 +204,15 @@ Page {
                                                             "stationName" : item.departureStation,
                                                             "stationInfo" : item.departureInfo,
                                                             "arrivalTime" : "",
-                                                            "departureTime" : Qt.formatTime(item.departureDateTime, Qt.DefaultLocaleShortDate),
+                                                            "departureTime" : Qt.formatTime(item.departureDateTime, "hh:mm"),
                                                             "isStation" : true,
                                                             "isTrain" : true
 
                         });
                     }
 
-                    //Add arrival station, but only if its the last item or if the next departureStation differs
-                    //from arrival station
-                    if (isStop || (nextItem && nextItem.departureStation != item.arrivalStation)) {
+                    //Add arrival station
+                    if (isStop) {
                         journeyDetailResultModel.append({
                                                             "isStart" : false,
                                                             "isStop" : isStop,
@@ -211,7 +221,7 @@ Page {
                                                             "trainInfo" : "",
                                                             "stationName" : item.arrivalStation,
                                                             "stationInfo" :  item.arrivalInfo,
-                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime, Qt.DefaultLocaleShortDate),
+                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime, "hh:mm"),
                                                             "departureTime" : "",
                                                             "isStation" : true,
                                                             "isTrain" : false
@@ -220,12 +230,15 @@ Page {
                     }
 
                     //Add one Station
-                    if ((nextItem && nextItem.departureStation == item.arrivalStation)) {
-
+                    if (nextItem) {
                         var stationInfo = item.arrivalInfo;
+                        var stationName = item.arrivalStation;
 
                         if (stationInfo.length > 0 && nextItem.departureInfo) {
                             stationInfo = stationInfo + " / ";
+                        }
+                        if (nextItem.departureStation != item.arrivalStation) {
+                            stationName += " / " + nextItem.departureStation;
                         }
 
                         stationInfo = stationInfo + nextItem.departureInfo;
@@ -236,10 +249,10 @@ Page {
                                                             "trainName" :  nextItem.train,
                                                             "trainDirection" : nextItem.direction,
                                                             "trainInfo" : nextItem.info,
-                                                            "stationName" : item.arrivalStation,
+                                                            "stationName" : stationName,
                                                             "stationInfo" : stationInfo,
-                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime, Qt.DefaultLocaleShortDate),
-                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime, Qt.DefaultLocaleShortDate),
+                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime, "hh:mm"),
+                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime, "hh:mm"),
                                                             "isStation" : true,
                                                             "isTrain" : true
 

--- a/src/gui/sailfishos/pages/JourneyDetailsResultsPage.qml
+++ b/src/gui/sailfishos/pages/JourneyDetailsResultsPage.qml
@@ -182,6 +182,17 @@ Page {
                         nextItem = result.getItem(i+1);
                     }
 
+                    /*
+                    console.log("-------------" + i);
+                    console.log(item.departureStation);
+                    console.log(item.train);
+                    console.log(item.arrivalStation);
+                    if (nextItem) {
+                        console.log(nextItem.departureStation);
+                        console.log(nextItem.train);
+                        console.log(nextItem.arrivalStation);
+                    }
+                    */
 
                     var isStart = (i == 0);
                     var isStop = (i == result.count -1);
@@ -204,9 +215,8 @@ Page {
                         });
                     }
 
-                    //Add arrival station, but only if its the last item or if the next departureStation differs
-                    //from arrival station
-                    if (isStop || (nextItem && nextItem.departureStation != item.arrivalStation)) {
+                    //Add arrival station
+                    if (isStop) {
                         journeyDetailResultModel.append({
                                                             "isStart" : false,
                                                             "isStop" : isStop,
@@ -224,12 +234,15 @@ Page {
                     }
 
                     //Add one Station
-                    if ((nextItem && nextItem.departureStation == item.arrivalStation)) {
-
+                    if (nextItem) {
                         var stationInfo = item.arrivalInfo;
+                        var stationName = item.arrivalStation;
 
                         if (stationInfo.length > 0 && nextItem.departureInfo) {
                             stationInfo = stationInfo + " / ";
+                        }
+                        if (nextItem.departureStation != item.arrivalStation) {
+                            stationName += " / " + nextItem.departureStation;
                         }
 
                         stationInfo = stationInfo + nextItem.departureInfo;
@@ -240,7 +253,7 @@ Page {
                                                             "trainName" :  nextItem.train,
                                                             "trainDirection" : nextItem.direction,
                                                             "trainInfo" : nextItem.info,
-                                                            "stationName" : item.arrivalStation,
+                                                            "stationName" : stationName,
                                                             "stationInfo" : stationInfo,
                                                             "arrivalTime" : Qt.formatTime(item.arrivalDateTime, "hh:mm"),
                                                             "departureTime" :  Qt.formatTime(nextItem.departureDateTime, "hh:mm"),
@@ -251,7 +264,6 @@ Page {
                     }
 
                 }
-
                 indicator.visible = false;
             } else {
                 pageStack.pop();

--- a/src/gui/symbian/pages/JourneyDetailsResultsPage.qml
+++ b/src/gui/symbian/pages/JourneyDetailsResultsPage.qml
@@ -181,6 +181,17 @@ Page {
                         nextItem = result.getItem(i+1);
                     }
 
+                    /*
+                    console.log("-------------" + i);
+                    console.log(item.departureStation);
+                    console.log(item.train);
+                    console.log(item.arrivalStation);
+                    if (nextItem) {
+                        console.log(nextItem.departureStation);
+                        console.log(nextItem.train);
+                        console.log(nextItem.arrivalStation);
+                    }
+                    */
 
                     var isStart = (i == 0);
                     var isStop = (i == result.count -1);
@@ -196,16 +207,15 @@ Page {
                                                             "stationName" : item.departureStation,
                                                             "stationInfo" : item.departureInfo,
                                                             "arrivalTime" : "",
-                                                            "departureTime" : Qt.formatTime(item.departureDateTime, Qt.DefaultLocaleShortDate),
+                                                            "departureTime" : Qt.formatTime(item.departureDateTime, "hh:mm"),
                                                             "isStation" : true,
                                                             "isTrain" : true
 
                         });
                     }
 
-                    //Add arrival station, but only if its the last item or if the next departureStation differs
-                    //from arrival station
-                    if (isStop || (nextItem && nextItem.departureStation != item.arrivalStation)) {
+                    //Add arrival station
+                    if (isStop) {
                         journeyDetailResultModel.append({
                                                             "isStart" : false,
                                                             "isStop" : isStop,
@@ -214,7 +224,7 @@ Page {
                                                             "trainInfo" : "",
                                                             "stationName" : item.arrivalStation,
                                                             "stationInfo" :  item.arrivalInfo,
-                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime, Qt.DefaultLocaleShortDate),
+                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime, "hh:mm"),
                                                             "departureTime" : "",
                                                             "isStation" : true,
                                                             "isTrain" : false
@@ -223,12 +233,15 @@ Page {
                     }
 
                     //Add one Station
-                    if ((nextItem && nextItem.departureStation == item.arrivalStation)) {
-
+                    if (nextItem) {
                         var stationInfo = item.arrivalInfo;
+                        var stationName = item.arrivalStation;
 
                         if (stationInfo.length > 0 && nextItem.departureInfo) {
                             stationInfo = stationInfo + " / ";
+                        }
+                        if (nextItem.departureStation != item.arrivalStation) {
+                            stationName += " / " + nextItem.departureStation;
                         }
 
                         stationInfo = stationInfo + nextItem.departureInfo;
@@ -239,10 +252,10 @@ Page {
                                                             "trainName" :  nextItem.train,
                                                             "trainDirection" : nextItem.direction,
                                                             "trainInfo" : nextItem.info,
-                                                            "stationName" : item.arrivalStation,
+                                                            "stationName" : stationName,
                                                             "stationInfo" : stationInfo,
-                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime, Qt.DefaultLocaleShortDate),
-                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime, Qt.DefaultLocaleShortDate),
+                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime, "hh:mm"),
+                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime, "hh:mm"),
                                                             "isStation" : true,
                                                             "isTrain" : true
 

--- a/src/gui/ubuntu/JourneyDetailsResultsPage.qml
+++ b/src/gui/ubuntu/JourneyDetailsResultsPage.qml
@@ -375,6 +375,17 @@ Page {
                         nextItem = result.getItem(i+1);
                     }
 
+                    /*
+                    console.log("-------------" + i);
+                    console.log(item.departureStation);
+                    console.log(item.train);
+                    console.log(item.arrivalStation);
+                    if (nextItem) {
+                        console.log(nextItem.departureStation);
+                        console.log(nextItem.train);
+                        console.log(nextItem.arrivalStation);
+                    }
+                    */
 
                     var isStart = (i == 0);
                     var isStop = (i == result.count -1);
@@ -390,16 +401,15 @@ Page {
                                                             "stationName" : item.departureStation,
                                                             "stationInfo" : item.departureInfo,
                                                             "arrivalTime" : "",
-                                                            "departureTime" : Qt.formatTime(item.departureDateTime, Qt.DefaultLocaleShortDate),
+                                                            "departureTime" : Qt.formatTime(item.departureDateTime, "hh:mm"),
                                                             "isStation" : true,
                                                             "isTrain" : true
 
                         });
                     }
 
-                    //Add arrival station, but only if its the last item or if the next departureStation differs
-                    //from arrival station
-                    if (isStop || (nextItem && nextItem.departureStation != item.arrivalStation)) {
+                    //Add arrival station
+                    if (isStop) {
                         journeyDetailResultModel.append({
                                                             "isStart" : false,
                                                             "isStop" : isStop,
@@ -408,7 +418,7 @@ Page {
                                                             "trainInfo" : "",
                                                             "stationName" : item.arrivalStation,
                                                             "stationInfo" :  item.arrivalInfo,
-                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime, Qt.DefaultLocaleShortDate),
+                                                            "arrivalTime" :  Qt.formatTime(item.arrivalDateTime, "hh:mm"),
                                                             "departureTime" : "",
                                                             "isStation" : true,
                                                             "isTrain" : false
@@ -417,12 +427,15 @@ Page {
                     }
 
                     //Add one Station
-                    if ((nextItem && nextItem.departureStation == item.arrivalStation)) {
-
+                    if (nextItem) {
                         var stationInfo = item.arrivalInfo;
+                        var stationName = item.arrivalStation;
 
                         if (stationInfo.length > 0 && nextItem.departureInfo) {
                             stationInfo = stationInfo + " / ";
+                        }
+                        if (nextItem.departureStation != item.arrivalStation) {
+                            stationName += " / " + nextItem.departureStation;
                         }
 
                         stationInfo = stationInfo + nextItem.departureInfo;
@@ -433,10 +446,10 @@ Page {
                                                             "trainName" :  nextItem.train,
                                                             "trainDirection" : nextItem.direction,
                                                             "trainInfo" : nextItem.info,
-                                                            "stationName" : item.arrivalStation,
+                                                            "stationName" : stationName,
                                                             "stationInfo" : stationInfo,
-                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime, Qt.DefaultLocaleShortDate),
-                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime, Qt.DefaultLocaleShortDate),
+                                                            "arrivalTime" : Qt.formatTime(item.arrivalDateTime, "hh:mm"),
+                                                            "departureTime" :  Qt.formatTime(nextItem.departureDateTime, "hh:mm"),
                                                             "isStation" : true,
                                                             "isTrain" : true
 


### PR DESCRIPTION
This is a fix for #163 but should also fix  #131 (by hardcodeing date format to 'hh:mm')

This fix changes the way the details-page renders the stations, i don't remember why i did it the way it's currently is, but it causes problems with the MVV-efa backend. departure  != arrival station, in comparison with bahn.de backend where they are the same.

I compared the render of some results with the old render method and it looks the same. so it seams this change causes no problems, but i don't know if this is true for all detail pages.

Thats why i created it as a PR.

@leppa not sure how often you use fahrplan, but i use it maybe once every month, apart of development.
maybe you can try this fix :)