### PR TITLE
Don't show errors -8012 and -8020

### DIFF
--- a/src/parser/parser_efa.cpp
+++ b/src/parser/parser_efa.cpp
@@ -299,14 +299,18 @@ void ParserEFA::checkForError(QDomDocument *serverReplyDomDoc)
     for(int i = 0; i < errorNodeList.size(); ++i) {
         QDomNode node = errorNodeList.item(i);
         QString error = getAttribute(node, "type");
-        QString code = getAttribute(node, "code");
-        if (code == "-8011") {
+        int code = getAttribute(node, "code").toInt();
+        switch (code) {
+        case -8011: // (unknown error)
+        case -8012: // empty query
+        case -8020: // no results
             continue;
         }
-        if(error == "error" && code.toInt() < 0) {
+
+        if(error == "error" && code < 0) {
             QString errorText = node.toElement().text();
             if(errorText.length() < 1)
-                errorText = code;
+                errorText = QString::number(code);
             qDebug() << "Server Query Error:" << errorText << code;
             emit errorOccured(tr("Server Error: ") + errorText);
         }


### PR DESCRIPTION
When searching for stations by name these errors can occur:
- error -8012 occurs when the search string contains only spaces
- error -8020 occurs when the search delivers no results