### PR TITLE
[harmattan] added searchTimer (copied from symbian), disable predictive ...

### DIFF
--- a/src/gui/harmattan/pages/StationSelectPage.qml
+++ b/src/gui/harmattan/pages/StationSelectPage.qml
@@ -57,6 +57,7 @@ Page {
 
             TextField {
                 id: searchBox
+                inputMethodHints: Qt.ImhNoPredictiveText
                 anchors {
                     left: parent.left
                     leftMargin: 10
@@ -66,7 +67,7 @@ Page {
                     topMargin: 10
                 }
 
-                onTextChanged: search.findStationsByName();
+                onTextChanged: searchTimer.restart();
                 Keys.onReturnPressed: search.findStationsByName();
                 Keys.onEnterPressed: search.findStationsByName();
 
@@ -89,10 +90,21 @@ Page {
                 }
             }
 
+            Timer {
+                id: searchTimer
+                interval: 1000
+                onTriggered: {
+                    search.findStationsByName();
+                }
+            }
+
             function findStationsByName()
             {
                 if (searchBox.text == "")
                     return;
+
+                if (searchTimer.running)
+                    searchTimer.stop();
 
                 indicator.show(qsTr("Searching ..."));
                 tabs.currentTab = stationSearchResultsTab;


### PR DESCRIPTION
This is completely untested (I don't have the harmattan sdk).
But "inputMethodHints: Qt.ImhNoPredictiveText" should make sure that the textChanged signal is not blocked. (http://developer.nokia.com/community/discussion/showthread.php/231522-TextField-TextInput-do-not-emit-textChanged-signal)
