### PR TITLE
Build Ubuntu Touch interface on Desktop (K)Ubuntu

### DIFF
--- a/desktop_res.qrc
+++ b/desktop_res.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file alias="fahrplan2_64.png">data/fahrplan2_64.png</file>
+    </qresource>
+</RCC>

--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -326,14 +326,36 @@ exists("/usr/include/sailfishapp/sailfishapp.h"): {
 }
 
 win32|unix:!simulator:!maemo5:!contains(MEEGO_EDITION,harmattan):!symbian:!exists("/usr/include/sailfishapp/sailfishapp.h") {
-
     QT += widgets
-
-    SOURCES += src/gui/desktop-test/mainwindow.cpp
-    HEADERS += src/gui/desktop-test/mainwindow.h
-    FORMS += src/gui/desktop-test/mainwindow.ui
-
     DEFINES += BUILD_FOR_DESKTOP
+    RESOURCES += desktop_res.qrc
+    equals (QML, true) {
+        RESOURCES += ubuntu_res.qrc
+        OTHER_FILES += \
+            src/gui/ubuntu/MainPage.qml \
+            src/gui/ubuntu/JourneyResultsPage.qml \
+            src/gui/ubuntu/JourneyDetailsResultsPage.qml \
+            src/gui/ubuntu/TimeTableResultsPage.qml \
+            src/gui/ubuntu/main.qml \
+            src/gui/ubuntu/components/Scroller.qml \
+            src/gui/ubuntu/components/StationSelect.qml \
+            src/gui/ubuntu/components/DatePicker.qml \
+            src/gui/ubuntu/components/TimePicker.qml \
+            src/gui/ubuntu/AboutPage.qml \
+            src/gui/ubuntu/SettingsPage.qml \
+            data/fahrplan2_ubuntu.desktop \
+            qtc_packaging/ubuntu/changelog \
+            qtc_packaging/ubuntu/compat \
+            qtc_packaging/ubuntu/control \
+            qtc_packaging/ubuntu/copyright \
+            qtc_packaging/ubuntu/rules \
+            qtc_packaging/ubuntu/source/format
+        DEFINES += BUILD_FOR_UBUNTU
+    } else {
+        SOURCES += src/gui/desktop-test/mainwindow.cpp
+        HEADERS += src/gui/desktop-test/mainwindow.h
+        FORMS += src/gui/desktop-test/mainwindow.ui
+    }
 }
 
 symbian|simulator {

--- a/src/gui/ubuntu/components/StationSelect.qml
+++ b/src/gui/ubuntu/components/StationSelect.qml
@@ -72,7 +72,7 @@ Page {
                 }
                 inputMethodHints: Qt.ImhNoPredictiveText
 
-                onTextChanged: search.findStationsByName();
+                onTextChanged: searchTimer.restart();
                 Keys.onReturnPressed: search.findStationsByName();
                 Keys.onEnterPressed: search.findStationsByName();
 
@@ -94,12 +94,23 @@ Page {
                 ]
             }
 
+            Timer {
+                id: searchTimer
+                interval: 500
+                onTriggered: {
+                    search.findStationsByName();
+                }
+            }
+
             function findStationsByName()
             {
                 if (searchBox.text == "") {
                     listView.model = fahrplanBackend.favorites
                     return;
                 }
+
+                if (searchTimer.running)
+                    searchTimer.stop();
 
                 indicator.running = true;
                 stationSelect.showFavorites = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,10 @@ int main(int argc, char *argv[])
         QApplication* app = MDeclarativeCache::qApplication(argc, argv);
     #else
         QApplication* app = new QApplication(argc, argv);
+        #if defined(BUILD_FOR_DESKTOP)
+            QIcon icon(":/fahrplan2_64.png");
+            app->setWindowIcon(icon);
+        #endif
     #endif
 
     QString localeName = QLocale().name();


### PR DESCRIPTION
I had to install the following dependencies first (Kubuntu 14.10):
qtdeclarative5-qtlocation-plugin
qtdeclarative5-qtpositioning-plugin
qtdeclarative5-ubuntu-ui-toolkit-plugin

First you have to run:
```
make distclean
qmake QML=true
```
Known issue: The window size on startup is a bit small and also not restored on next start.

I also copied over the searchTimer but used a shorter delay (500 ms).