### PR TITLE
fix favorites not hiding any more after a triggering an empty search.

### DIFF
--- a/src/gui/ubuntu/components/StationSelect.qml
+++ b/src/gui/ubuntu/components/StationSelect.qml
@@ -105,7 +105,7 @@ Page {
             function findStationsByName()
             {
                 if (searchBox.text == "") {
-                    listView.model = fahrplanBackend.favorites
+                    stationSelect.showFavorites = true;
                     return;
                 }
 


### PR DESCRIPTION
Don't change the model when triggering an empty search. There's a bool
property that triggers a binding for this instead.