### PR TITLE
[ubuntu] make selecting between NowMode, DepartureMode and ArrivalMode working

### DIFF
--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -255,6 +255,10 @@ Page {
                     id: timeModeSelector
                     text: qsTr("Date and time")
                     values: [qsTr("Now"), qsTr("Departure"), qsTr("Arrival")]
+                    selectedIndex: (fahrplanBackend.mode + 1) % 3
+                    onSelectedIndexChanged: {
+                        fahrplanBackend.mode = (timeModeSelector.selectedIndex + 2) % 3;
+                    }
                 }
 
                 ListItems.Subtitled {


### PR DESCRIPTION
First Part: FahrplanBackend loads its mode on start-up from the config file, so set it accordingly in the UI.
Second Part: When the selected mode changes, tell FahrplanBackend