### PR TITLE
Maintenance Update to Ubuntu version

### DIFF
--- a/qtc_packaging/ubuntu/fahrplan2.json
+++ b/qtc_packaging/ubuntu/fahrplan2.json
@@ -1,4 +1,4 @@
 {
     "policy_groups": ["networking", "location"],
-    "policy_version": 1.1
+    "policy_version": 1.2
 }

--- a/qtc_packaging/ubuntu/manifest.json
+++ b/qtc_packaging/ubuntu/manifest.json
@@ -1,6 +1,6 @@
 {
     "description": "A journey planner for public transportation.",
-    "framework": "ubuntu-sdk-14.04",
+    "framework": "ubuntu-sdk-14.10",
     "architecture": "armhf",
     "hooks": {
         "fahrplan2": {

--- a/src/gui/ubuntu/JourneyDetailsResultsPage.qml
+++ b/src/gui/ubuntu/JourneyDetailsResultsPage.qml
@@ -462,7 +462,7 @@ Page {
                 }
                 searchIndicator.visible = false;
             } else {
-                pageStack.pop();
+                mainStack.pop();
             }
         }
     }

--- a/src/gui/ubuntu/JourneyDetailsResultsPage.qml
+++ b/src/gui/ubuntu/JourneyDetailsResultsPage.qml
@@ -23,8 +23,9 @@ import Ubuntu.Components 1.1
 import "components"
 
 Page {
-    title: qsTr("Result Details")
     id: searchDetailResultsPage
+
+    title: qsTr("Result Details")
 
     property alias titleText: journeyStations.text
     property alias subTitleText: lbljourneyDate.text
@@ -33,7 +34,6 @@ Page {
 
     property JourneyDetailResultList currentResult;
 
-//    tools: journeyDetailResultsToolbar
     Item {
         id: searchResults
 

--- a/src/gui/ubuntu/JourneyResultsPage.qml
+++ b/src/gui/ubuntu/JourneyResultsPage.qml
@@ -23,12 +23,13 @@ import Ubuntu.Components 1.1
 import "components"
 
 Page {
+    id: searchResultsPage
+
     title: qsTr("Results")
+
     property alias searchResults: searchResults
     property alias journeyStationsTitleText: journeyStations.text
     property alias searchIndicatorVisible: searchIndicator.visible
-
-    id: searchResultsPage
 
     Item {
         id: searchResults

--- a/src/gui/ubuntu/JourneyResultsPage.qml
+++ b/src/gui/ubuntu/JourneyResultsPage.qml
@@ -210,7 +210,7 @@ Page {
                 onClicked: {
 
                     var component = Qt.createComponent("JourneyDetailsResultsPage.qml")
-                    pageStack.push(component,
+                    mainStack.push(component,
                                    {titleText: qsTr("Loading details"), subTitleText: qsTr("please wait..."), searchIndicatorVisible: true});
                     fahrplanBackend.parser.getJourneyDetails(id);
                 }

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -27,10 +27,22 @@ import Fahrplan 1.0
 Page {
     id: mainPage
 
-    tools: mainToolbar
-
     property int searchmode : 0
     property bool startup : true
+
+    head.actions: [
+        Action {
+            iconName: "info"
+            text: qsTr("About")
+            onTriggered: mainStack.push(Qt.resolvedUrl("AboutPage.qml"));
+        }
+
+        // Not using settings on ubuntu yet...
+//        Action {
+//            iconSource: "file:///usr/share/icons/ubuntu-mobile/actions/scalable/settings.svg"
+//            onTriggered: pageStack.push(Qt.resolvedUrl("SettingsPage.qml"));
+//        }
+    ]
 
     Component.onCompleted: {
         updateButtonVisibility()
@@ -441,23 +453,6 @@ Page {
         id: timePicker
         TimePicker {
 
-        }
-    }
-
-    ToolbarItems {
-        id: mainToolbar
-
-        // Not using settings on ubuntu yet...
-//        Action {
-//            iconSource: "file:///usr/share/icons/ubuntu-mobile/actions/scalable/settings.svg"
-//            onTriggered: pageStack.push(Qt.resolvedUrl("SettingsPage.qml"));
-//        }
-        ToolbarButton {
-            action: Action {
-                iconName: "info"
-                text: qsTr("About")
-                onTriggered: mainStack.push(Qt.resolvedUrl("AboutPage.qml"));
-            }
         }
     }
 

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -164,9 +164,9 @@ Page {
                     property int type: FahrplanBackend.DepartureStation
 
                     onClicked: {
-                        pageStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
-                        pageStack.currentPage.stationSelected.connect(function() {
-                            pageStack.pop();
+                        mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
+                        mainStack.currentPage.stationSelected.connect(function() {
+                            mainStack.pop();
                         })
                     }
                     onPressAndHold: {
@@ -185,10 +185,11 @@ Page {
                     property int type: FahrplanBackend.ViaStation
 
                     onClicked: {
-                        pageStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
-                        pageStack.currentPage.stationSelected.connect(function() {
-                            pageStack.pop();
+                        mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
+                        mainStack.currentPage.stationSelected.connect(function() {
+                            mainStack.pop();
                         })
+
                     }
                     onPressAndHold: {
                         openMenu(viaButton);
@@ -206,9 +207,9 @@ Page {
                     property int type: FahrplanBackend.ArrivalStation
 
                     onClicked: {
-                        pageStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
-                        pageStack.currentPage.stationSelected.connect(function() {
-                            pageStack.pop();
+                        mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
+                        mainStack.currentPage.stationSelected.connect(function() {
+                            mainStack.pop();
                         })
                     }
                     onPressAndHold: {
@@ -225,9 +226,9 @@ Page {
                     }
                     progression: true
                     onClicked: {
-                        pageStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: FahrplanBackend.CurrentStation})
-                        pageStack.currentPage.stationSelected.connect(function(name) {
-                            pageStack.pop();
+                        mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: FahrplanBackend.CurrentStation})
+                        mainStack.currentPage.stationSelected.connect(function() {
+                            mainStack.pop();
                         })
                     }
                 }
@@ -241,9 +242,9 @@ Page {
                     }
                     progression: true
                     onClicked: {
-                        pageStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: FahrplanBackend.DirectionStation})
-                        pageStack.currentPage.stationSelected.connect(function() {
-                            pageStack.pop();
+                        mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: FahrplanBackend.DirectionStation})
+                        mainStack.currentPage.stationSelected.connect(function() {
+                            mainStack.pop();
                         })
                     }
                     onPressAndHold: {
@@ -329,7 +330,7 @@ Page {
                         }
 
                         onClicked: {
-                            pageStack.push("qrc:///src/gui/ubuntu/TimeTableResultsPage.qml", {searchIndicatorVisible: true});
+                            mainStack.push("qrc:///src/gui/ubuntu/TimeTableResultsPage.qml", {searchIndicatorVisible: true});
                             fahrplanBackend.getTimeTable();
                         }
                     }
@@ -353,7 +354,7 @@ Page {
                                 titleText = qsTr("<b>%1</b> via <b>%3</b> to <b>%2</b>").arg(departureButton.subText).arg(arrivalButton.subText).arg(viaButton.subText)
                             }
 
-                            pageStack.push("qrc:///src/gui/ubuntu/JourneyResultsPage.qml", {journeyStationsTitleText: titleText, searchIndicatorVisible: true })
+                            mainStack.push("qrc:///src/gui/ubuntu/JourneyResultsPage.qml", {journeyStationsTitleText: titleText, searchIndicatorVisible: true })
                             fahrplanBackend.searchJourney();
                         }
                     }
@@ -455,7 +456,7 @@ Page {
             action: Action {
                 iconName: "info"
                 text: qsTr("About")
-                onTriggered: pageStack.push(Qt.resolvedUrl("AboutPage.qml"));
+                onTriggered: mainStack.push(Qt.resolvedUrl("AboutPage.qml"));
             }
         }
     }

--- a/src/gui/ubuntu/TimeTableResultsPage.qml
+++ b/src/gui/ubuntu/TimeTableResultsPage.qml
@@ -34,7 +34,7 @@ Page {
     head.backAction: Action {
         iconName: "back"
         onTriggered: {
-            pageStack.pop()
+            mainStack.pop()
             fahrplanBackend.parser.cancelRequest();
         }
     }

--- a/src/gui/ubuntu/main.qml
+++ b/src/gui/ubuntu/main.qml
@@ -23,41 +23,33 @@ import Fahrplan 1.0
 
 MainView {
     id: appWindow
-    width: units.gu(40)
-    height: units.gu(71)
+
+    width: units.gu(40); height: units.gu(71)
+    useDeprecatedToolbar: false
 
     FahrplanBackend {
         id: fahrplanBackend
     }
 
-    useDeprecatedToolbar: false
-    Tabs {
-        onCurrentPageChanged: {
-            while (journeyPageStack.depth > 1) {
-                journeyPageStack.pop()
-            }
-            while (timeTablePageStack.depth > 1) {
-                timeTablePageStack.pop()
-            }
-        }
+    PageStack {
+        id: mainStack
 
-        Tab {
-            title: qsTr("Journey")
-            page: PageStack {
-                id: journeyPageStack
-                Component.onCompleted: push(journeyPage)
-                MainPage {
+        Component.onCompleted: push(tabs)
+
+        Tabs {
+            id: tabs
+
+            Tab {
+                title: qsTr("Journey")
+                page: MainPage {
                     title: qsTr("Journey")
                     id: journeyPage
                 }
             }
-        }
-        Tab {
-            title: qsTr("Time table")
-            page: PageStack {
-                id: timeTablePageStack
-                Component.onCompleted: push(timeTablePage)
-                MainPage {
+
+            Tab {
+                title: qsTr("Time table")
+                page: MainPage {
                     title: qsTr("Time table")
                     id: timeTablePage
                     searchmode: 1


### PR DESCRIPTION
This pull request fixes the following,
- Updated SDK framework to ubuntu-sdk-14.10 and policy version to 1.2
- Removed uses of Toolbar items to page.head as per the newer SDK API
- Previously for some reason there were 2 pagestacks which was unnecessary. Simplified that to using just 1 central pagestack and tested for regressions.