### PR TITLE
[Ubuntu Touch] Minor UI Polish

### DIFF
--- a/data/fahrplan2_ubuntu.desktop
+++ b/data/fahrplan2_ubuntu.desktop
@@ -8,3 +8,4 @@ Exec=./bin/fahrplan2
 Icon=fahrplan2-square.svg
 X-Ubuntu-Touch=true
 X-Ubuntu-StageHint=SideStage
+X-Ubuntu-Splash-Color=#F5F5F5

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -325,18 +325,11 @@ Page {
                     model: parserBackendModel
                     delegate: ListItems.Standard {
                         text: modelData
-
-                        // FIXME: This is a workaround for the theme not being context sensitive. I.e. the
-                        // ListItems don't know that they are sitting in a themed Popover where the color
-                        // needs to be inverted.
-                        __foregroundColor: Theme.palette.selected.backgroundText
-
                         onClicked: {
                             fahrplanBackend.setParser(index);
                             PopupUtils.close(selectBackendDialog)
                         }
                     }
-
                 },
 
                 Button {

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -333,12 +333,11 @@ Page {
                 },
 
                 Button {
-                    text: "Close"
+                    text: qsTr("Close")
                     anchors.horizontalCenter: parent.horizontalCenter
                     onClicked: PopupUtils.close(selectBackendDialog)
                 }
             ]
-
         }
     }
 

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -273,6 +273,7 @@ Page {
 
             ListItems.Standard {
                 showDivider: false
+                height: units.gu(8)
                 Button {
                     id: timetableSearch
 

--- a/src/gui/ubuntu/components/StationSelect.qml
+++ b/src/gui/ubuntu/components/StationSelect.qml
@@ -42,7 +42,6 @@ Page {
                 stationSelect.showFavorites = !stationSelect.showFavorites
             }
         }
-
     ]
 
     Item {

--- a/src/gui/ubuntu/main.qml
+++ b/src/gui/ubuntu/main.qml
@@ -26,6 +26,7 @@ MainView {
 
     width: units.gu(40); height: units.gu(71)
     useDeprecatedToolbar: false
+    anchorToKeyboard: true
 
     FahrplanBackend {
         id: fahrplanBackend

--- a/ubuntu_res.qrc
+++ b/ubuntu_res.qrc
@@ -7,7 +7,6 @@
         <file>src/gui/ubuntu/AboutPage.qml</file>
         <file>src/gui/ubuntu/TimeTableResultsPage.qml</file>
         <file>src/gui/ubuntu/SettingsPage.qml</file>
-        <file>src/gui/ubuntu/components/Scroller.qml</file>
         <file>src/gui/ubuntu/components/DatePicker.qml</file>
         <file>src/gui/ubuntu/components/TimePicker.qml</file>
         <file>src/gui/ubuntu/components/StationSelect.qml</file>


### PR DESCRIPTION
This pull implements the following,

- It seems in pull request #199 I forgot to remove the reference to Scrollers.qml from the **ubuntu_res.qrc** and as such building it on ubuntu gave an error. This has been fixed.

-  Changed the app splash background color to White to match the application's background color. This should improve the app startup transition. [Mandatory Screenshot](https://imgur.com/xNcdXKQ)

- Cleaned up the StationSelect.qml file where there were few Item{} which weren't necessary. In the process I also cleaned up the padding and small design papercuts in that page. [Mandatory Screenshot](https://imgur.com/WwChikK).

- Enabled anchorToKeyboard provided by the Ubuntu SDK to ensure that the UI respects the presence of the on-screen keyboard.

- Removed dialog foreground workaround that is no longer needed due to it being fixed upstream in the Ubuntu SDK.