### PR TITLE
Fixes for memory leaks and QObject* ownership bugs

### DIFF
--- a/rpm/harbour-fahrplan2.yaml
+++ b/rpm/harbour-fahrplan2.yaml
@@ -15,8 +15,10 @@ PkgConfigBR:
 - Qt5Quick
 - Qt5Qml
 - Qt5Core
+- sailfishapp
 Requires:
 - sailfishsilica-qt5 >= 0.10.9
+- qt5-qtdeclarative-import-positioning
 Files:
 - '%{_datadir}/icons/hicolor/86x86/apps/%{name}.png'
 - '%{_datadir}/applications/%{name}.desktop'

--- a/src/fahrplan.h
+++ b/src/fahrplan.h
@@ -77,6 +77,7 @@ class Fahrplan : public QObject
         };
 
         explicit Fahrplan(QObject *parent = 0);
+        virtual ~Fahrplan();
         FahrplanParserThread *parser();
         Favorites *favorites() const;
         QString parserName() const;
@@ -141,6 +142,7 @@ class Fahrplan : public QObject
         void onStationSearchResults(const StationsList &result);
         void onTimetableResult(const TimetableEntriesList &timetableEntries);
         void bindParserSignals();
+        void unbindParserSignals();
 
     private:
         static FahrplanBackendManager *m_parser_manager;

--- a/src/fahrplan_backend_manager.cpp
+++ b/src/fahrplan_backend_manager.cpp
@@ -26,6 +26,14 @@ FahrplanBackendManager::FahrplanBackendManager(int defaultParser, QObject *paren
     currentParserIndex = defaultParser;
 }
 
+FahrplanBackendManager::~FahrplanBackendManager()
+{
+    if (m_parser) {
+        // Parser object will be autodeleted after the thread quits.
+        m_parser->quit();
+    }
+}
+
 QStringList FahrplanBackendManager::getParserList()
 {
     QStringList result;
@@ -68,7 +76,7 @@ void FahrplanBackendManager::setParser(int index)
         m_parser->quit();
     }
 
-    m_parser = new FahrplanParserThread();
+    m_parser = new FahrplanParserThread(this);
     m_parser->init(index);
 
     emit parserChanged(m_parser->name(), currentParserIndex);

--- a/src/fahrplan_backend_manager.h
+++ b/src/fahrplan_backend_manager.h
@@ -28,6 +28,7 @@ class FahrplanBackendManager : public QObject
 
     public:
         explicit FahrplanBackendManager(int defaultParser, QObject *parent = 0);
+        virtual ~FahrplanBackendManager();
         QStringList getParserList();
         void setParser(int index);
         FahrplanParserThread *getParser();

--- a/src/fahrplan_parser_thread.cpp
+++ b/src/fahrplan_parser_thread.cpp
@@ -76,6 +76,11 @@ void FahrplanParserThread::cancelRequest()
     emit requestCancelRequest();
 }
 
+void FahrplanParserThread::clearJourney()
+{
+    emit requestClearJourney();
+}
+
 QString FahrplanParserThread::name() {
     return m_name;
 }
@@ -182,6 +187,7 @@ void FahrplanParserThread::run()
     connect(this, SIGNAL(requestSearchJourney(Station,Station,Station,QDateTime,ParserAbstract::Mode,int)), m_parser, SLOT(searchJourney(Station,Station,Station,QDateTime,ParserAbstract::Mode,int)), Qt::QueuedConnection);
     connect(this, SIGNAL(requestSearchJourneyEarlier()), m_parser, SLOT(searchJourneyEarlier()), Qt::QueuedConnection);
     connect(this, SIGNAL(requestSearchJourneyLater()), m_parser, SLOT(searchJourneyLater()), Qt::QueuedConnection);
+    connect(this, SIGNAL(requestClearJourney()), m_parser, SLOT(clearJourney()), Qt::QueuedConnection);
 
     //Connect parser responses with threads corresponding results
     connect(m_parser, SIGNAL(errorOccured(QString)), this, SIGNAL(errorOccured(QString)), Qt::QueuedConnection);

--- a/src/fahrplan_parser_thread.h
+++ b/src/fahrplan_parser_thread.h
@@ -56,6 +56,7 @@ signals:
     void requestSearchJourneyEarlier();
     void requestGetJourneyDetails(const QString &id);
     void requestCancelRequest();
+    void requestClearJourney();
 
     //Real ones
     void stationsResult(const StationsList &result);
@@ -75,6 +76,7 @@ public slots:
     void searchJourneyEarlier();
     void getJourneyDetails(const QString &id);
     void cancelRequest();
+    void clearJourney();
 
     bool supportsGps();
     bool supportsVia();

--- a/src/fahrplan_parser_thread.h
+++ b/src/fahrplan_parser_thread.h
@@ -89,7 +89,7 @@ protected:
   void run();
 
 private:
-  bool m_ready;
+  volatile bool m_ready;
   int  i_parser;
 
   QStringList m_trainrestrictions;

--- a/src/parser/parser_abstract.cpp
+++ b/src/parser/parser_abstract.cpp
@@ -36,7 +36,7 @@
 #endif
 
 ParserAbstract::ParserAbstract(QObject *parent) :
-    QObject(parent)
+    QObject(parent), lastRequest(NULL)
 {
     NetworkManager = new QNetworkAccessManager(this);
     connect(NetworkManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(networkReplyFinished(QNetworkReply*)));

--- a/src/parser/parser_abstract.cpp
+++ b/src/parser/parser_abstract.cpp
@@ -43,7 +43,7 @@ ParserAbstract::ParserAbstract(QObject *parent) :
 
     currentRequestState = FahrplanNS::noneRequest;
 
-    requestTimeout = new QTimer();
+    requestTimeout = new QTimer(this);
 
     connect(requestTimeout, SIGNAL(timeout()), this, SLOT(networkReplyTimedOut()));
 
@@ -52,8 +52,14 @@ ParserAbstract::ParserAbstract(QObject *parent) :
 
 ParserAbstract::~ParserAbstract()
 {
+    clearJourney();
     delete requestTimeout;
     delete NetworkManager;
+}
+
+void ParserAbstract::clearJourney()
+{
+
 }
 
 void ParserAbstract::networkReplyFinished(QNetworkReply *networkReply)

--- a/src/parser/parser_abstract.h
+++ b/src/parser/parser_abstract.h
@@ -37,7 +37,7 @@ public:
     enum Mode { Departure = 0, Arrival = 1 };
 
     explicit ParserAbstract(QObject *parent = 0);
-    ~ParserAbstract();
+    virtual ~ParserAbstract();
 
     static QString getName() { return "Abstract"; }
     virtual QString name() { return getName(); }
@@ -58,6 +58,7 @@ public slots:
     virtual bool supportsTimeTableDirection();
     virtual QStringList getTrainRestrictions();
     void cancelRequest();
+    virtual void clearJourney();
 
 signals:
     void stationsResult(const StationsList &result);

--- a/src/parser/parser_definitions.cpp
+++ b/src/parser/parser_definitions.cpp
@@ -71,6 +71,16 @@ TimetableEntry::TimetableEntry()
 
 //------------- JourneyResultList
 
+JourneyResultList::JourneyResultList(QObject * parent) : QObject(parent)
+{
+
+}
+
+JourneyResultList::~JourneyResultList()
+{
+    qDeleteAll(m_items);
+}
+
 qreal JourneyResultList::itemcount()
 {
     return m_items.count();
@@ -233,6 +243,16 @@ void JourneyResultItem::setInternalData2(const QString &internalData2)
 }
 
 //------------- JourneyDetailResultList
+
+JourneyDetailResultList::JourneyDetailResultList(QObject * parent) : QObject(parent)
+{
+
+}
+
+JourneyDetailResultList::~JourneyDetailResultList()
+{
+    qDeleteAll(m_items);
+}
 
 QString JourneyDetailResultList::id() const
 {

--- a/src/parser/parser_definitions.cpp
+++ b/src/parser/parser_definitions.cpp
@@ -127,6 +127,10 @@ void JourneyResultList::setTimeInfo(const QString &timeInfo)
 }
 
 //------------- JourneyResultItem
+JourneyResultItem::JourneyResultItem(QObject *parent) : QObject(parent)
+{
+
+}
 
 QString JourneyResultItem::id() const
 {
@@ -326,6 +330,11 @@ void JourneyDetailResultList::setDuration(const QString &duration)
 }
 
 //------------- JourneyDetailResultItem
+
+JourneyDetailResultItem::JourneyDetailResultItem(QObject *parent) : QObject(parent)
+{
+
+}
 
 QString JourneyDetailResultItem::departureStation() const
 {

--- a/src/parser/parser_definitions.h
+++ b/src/parser/parser_definitions.h
@@ -95,6 +95,7 @@ class JourneyResultItem : public QObject
     Q_PROPERTY(QString internalData2 READ internalData2 WRITE setInternalData2)
 
     public:
+        explicit JourneyResultItem(QObject * parent = 0);
         QString id() const;
         void setId(const QString &);
         QDate date() const;
@@ -176,6 +177,7 @@ class JourneyDetailResultItem : public QObject
     Q_PROPERTY(QString internalData1 READ internalData1 WRITE setInternalData1)
     Q_PROPERTY(QString internalData2 READ internalData2 WRITE setInternalData2)
     public:
+        explicit JourneyDetailResultItem(QObject * parent = 0);
         QString departureStation() const;
         void setDepartureStation(const QString &);
         QString departureInfo() const;

--- a/src/parser/parser_definitions.h
+++ b/src/parser/parser_definitions.h
@@ -141,6 +141,8 @@ class JourneyResultList : public QObject
     public slots:
         JourneyResultItem *getItem(int);
     public:
+        explicit JourneyResultList(QObject * parent = 0);
+        virtual ~JourneyResultList();
         void appendItem(JourneyResultItem *item);
         qreal itemcount();
         QString departureStation() const;
@@ -230,6 +232,8 @@ class JourneyDetailResultList : public QObject
     public slots:
         JourneyDetailResultItem *getItem(int);
     public:
+        explicit JourneyDetailResultList(QObject * parent = 0);
+        virtual ~JourneyDetailResultList();
         void appendItem(JourneyDetailResultItem *item);
         qreal itemcount();
         QString id() const;

--- a/src/parser/parser_efa.cpp
+++ b/src/parser/parser_efa.cpp
@@ -102,7 +102,8 @@
 QHash<QString, JourneyDetailResultList *> cachedJourneyDetailsEfa;
 
 ParserEFA::ParserEFA(QObject *parent) :
-    ParserAbstract(parent){
+    ParserAbstract(parent), lastJourneyResultList(NULL)
+{
 
     m_searchJourneyParameters.isValid = false;
     m_timeTableForStationParameters.isValid = false;

--- a/src/parser/parser_efa.cpp
+++ b/src/parser/parser_efa.cpp
@@ -422,6 +422,8 @@ void ParserEFA::searchJourney(const Station &departureStation, const Station &vi
         return;
     currentRequestState = FahrplanNS::searchJourneyRequest;
 
+    clearJourney();
+
     m_searchJourneyParameters.isValid = false;
     m_searchJourneyParameters.departureStation = departureStation;
     m_searchJourneyParameters.arrivalStation = arrivalStation;
@@ -524,7 +526,6 @@ void ParserEFA::searchJourney(const Station &departureStation, const Station &vi
 void ParserEFA::parseSearchJourney(QNetworkReply *networkReply)
 {
     qDebug() << "ParserEFA::parseSearchJourney(QNetworkReply *networkReply)";
-    clearJourney();
 
     lastJourneyResultList = new JourneyResultList(this);
 

--- a/src/parser/parser_efa.cpp
+++ b/src/parser/parser_efa.cpp
@@ -519,7 +519,7 @@ void ParserEFA::parseSearchJourney(QNetworkReply *networkReply)
     qDebug() << "ParserEFA::parseSearchJourney(QNetworkReply *networkReply)";
     clearJourney();
 
-    lastJourneyResultList = new JourneyResultList();
+    lastJourneyResultList = new JourneyResultList(this);
 
     for (QHash<QString, JourneyDetailResultList *>::Iterator it = cachedJourneyDetailsEfa.begin(); it != cachedJourneyDetailsEfa.end();) {
         JourneyDetailResultList *jdrl = it.value();
@@ -634,20 +634,19 @@ void ParserEFA::searchJourneyLater()
 {
     qDebug() << "ParserEFA::searchJourneyLater()";
 
-    if (m_latestResultDeparture.isValid())
-    {
+    if (m_latestResultDeparture.isValid()) {
         qDebug() << "m_latestResultDeparture.isValid()";
         searchJourney(m_searchJourneyParameters.departureStation, m_searchJourneyParameters.viaStation, m_searchJourneyParameters.arrivalStation, m_latestResultDeparture, Departure, 0);
-    }
-    else {
+    } else {
         qDebug() << "!m_latestResultDeparture.isValid(), ";
-        JourneyResultList *journeyResultList = new JourneyResultList();
-        journeyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
-        journeyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
-        journeyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
+        clearJourney();
+        lastJourneyResultList = new JourneyResultList(this);
+        lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
+        lastJourneyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
+        lastJourneyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
         //: DATE, TIME
-        journeyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
-        emit journeyResult(journeyResultList);
+        lastJourneyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
+        emit journeyResult(lastJourneyResultList);
     }
 }
 
@@ -657,13 +656,14 @@ void ParserEFA::searchJourneyEarlier()
     if (m_earliestArrival.isValid())
         searchJourney(m_searchJourneyParameters.departureStation, m_searchJourneyParameters.viaStation, m_searchJourneyParameters.arrivalStation, m_earliestArrival, Arrival, 0);
     else {
-        JourneyResultList *journeyResultList = new JourneyResultList();
-        journeyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
-        journeyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
-        journeyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
+        clearJourney();
+        lastJourneyResultList = new JourneyResultList(this);
+        lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
+        lastJourneyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
+        lastJourneyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
         //: DATE, TIME
-        journeyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
-        emit journeyResult(journeyResultList);
+        lastJourneyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
+        emit journeyResult(lastJourneyResultList);
     }
 }
 

--- a/src/parser/parser_efa.cpp
+++ b/src/parser/parser_efa.cpp
@@ -108,6 +108,19 @@ ParserEFA::ParserEFA(QObject *parent) :
     m_timeTableForStationParameters.isValid = false;
 }
 
+ParserEFA::~ParserEFA()
+{
+    clearJourney();
+}
+
+void ParserEFA::clearJourney()
+{
+    if (lastJourneyResultList) {
+        delete lastJourneyResultList;
+        lastJourneyResultList = NULL;
+    }
+}
+
 bool ParserEFA::supportsGps()
 {
     return true;
@@ -504,6 +517,8 @@ void ParserEFA::searchJourney(const Station &departureStation, const Station &vi
 void ParserEFA::parseSearchJourney(QNetworkReply *networkReply)
 {
     qDebug() << "ParserEFA::parseSearchJourney(QNetworkReply *networkReply)";
+    clearJourney();
+
     lastJourneyResultList = new JourneyResultList();
 
     for (QHash<QString, JourneyDetailResultList *>::Iterator it = cachedJourneyDetailsEfa.begin(); it != cachedJourneyDetailsEfa.end();) {

--- a/src/parser/parser_efa.cpp
+++ b/src/parser/parser_efa.cpp
@@ -542,7 +542,7 @@ void ParserEFA::parseSearchJourney(QNetworkReply *networkReply)
                 info = tr("Guaranteed connection");
             }
             motNameList.append(motName);
-            JourneyDetailResultItem *jdrItem = new JourneyDetailResultItem();
+            JourneyDetailResultItem *jdrItem = new JourneyDetailResultItem(detailsList);
             jdrItem->setTrain(motName);
             jdrItem->setInfo(info);
             jdrItem->setDirection(motElement.attribute("destination"));
@@ -580,7 +580,7 @@ void ParserEFA::parseSearchJourney(QNetworkReply *networkReply)
         detailsList->setDepartureDateTime(departureDateTime);
         cachedJourneyDetailsEfa[id] = detailsList;
 
-        JourneyResultItem *item = new JourneyResultItem();
+        JourneyResultItem *item = new JourneyResultItem(lastJourneyResultList);
         item->setDate(departureDateTime.date());
         item->setId(id);
         item->setTransfers(changes);

--- a/src/parser/parser_efa.h
+++ b/src/parser/parser_efa.h
@@ -61,6 +61,7 @@ protected:
 
 private:
     JourneyResultList *lastJourneyResultList;
+    QHash<QString, JourneyDetailResultList *> cachedJourneyDetailsEfa;
 
     struct {
         bool isValid;

--- a/src/parser/parser_efa.h
+++ b/src/parser/parser_efa.h
@@ -29,6 +29,7 @@ class ParserEFA : public ParserAbstract
     Q_OBJECT
 public:
     explicit ParserEFA(QObject *parent = 0);
+    virtual ~ParserEFA();
     static QString getName() { return "EFA"; }
     virtual QString name() { return getName(); }
     virtual QString shortName() { return getName(); }
@@ -47,6 +48,7 @@ public slots:
     bool supportsTimeTableDirection();
     void checkForError(QDomDocument *serverReplyDomDoc);
     QStringList getTrainRestrictions();
+    virtual void clearJourney();
 
 protected:
     QString baseRestUrl;

--- a/src/parser/parser_hafasbinary.cpp
+++ b/src/parser/parser_hafasbinary.cpp
@@ -634,6 +634,8 @@ void ParserHafasBinary::searchJourneyLater()
 
     currentRequestState = FahrplanNS::searchJourneyLaterRequest;
 
+    clearJourney();
+
     QUrl uri = baseBinaryUrl;
 #if defined(BUILD_FOR_QT5)
     QUrlQuery query;
@@ -668,6 +670,8 @@ void ParserHafasBinary::searchJourneyEarlier()
     }
 
     currentRequestState = FahrplanNS::searchJourneyEarlierRequest;
+
+    clearJourney();
 
     QUrl uri = baseBinaryUrl;
 #if defined(BUILD_FOR_QT5)

--- a/src/parser/parser_hafasbinary.cpp
+++ b/src/parser/parser_hafasbinary.cpp
@@ -44,7 +44,7 @@ void ParserHafasBinary::searchJourney(const Station &departureStation, const Sta
     currentRequestState = FahrplanNS::searchJourneyRequest;
     hafasContext.seqNr = "";
 
-    cleanupJourney();
+    clearJourney();
 
     QString trainrestr = getTrainRestrictionsCodes(trainrestrictions);
 

--- a/src/parser/parser_hafasbinary.cpp
+++ b/src/parser/parser_hafasbinary.cpp
@@ -43,7 +43,8 @@ void ParserHafasBinary::searchJourney(const Station &departureStation, const Sta
 
     currentRequestState = FahrplanNS::searchJourneyRequest;
     hafasContext.seqNr = "";
-    lastJourneyResultList = NULL;
+
+    cleanupJourney();
 
     QString trainrestr = getTrainRestrictionsCodes(trainrestrictions);
 
@@ -85,8 +86,8 @@ void ParserHafasBinary::searchJourney(const Station &departureStation, const Sta
 
 void ParserHafasBinary::parseSearchJourney(QNetworkReply *networkReply)
 {
-    lastJourneyResultList = new JourneyResultList();
-    journeyDetailInlineData.clear();
+    lastJourneyResultList = new JourneyResultList(this);
+
     stringCache.clear();
 
     QByteArray tmpBuffer = networkReply->readAll();
@@ -324,7 +325,7 @@ void ParserHafasBinary::parseSearchJourney(QNetworkReply *networkReply)
             qDebug()<<"conId"<<connectionId;
             QStringList lineNames;
 
-            JourneyDetailResultList *inlineResults = new JourneyDetailResultList();
+            JourneyDetailResultList *inlineResults = new JourneyDetailResultList(this);
 
             for (int iPart = 0; iPart < numParts; iPart++) {
 

--- a/src/parser/parser_hafasbinary.cpp
+++ b/src/parser/parser_hafasbinary.cpp
@@ -328,7 +328,7 @@ void ParserHafasBinary::parseSearchJourney(QNetworkReply *networkReply)
 
             for (int iPart = 0; iPart < numParts; iPart++) {
 
-                JourneyDetailResultItem *inlineItem = new JourneyDetailResultItem();
+                JourneyDetailResultItem *inlineItem = new JourneyDetailResultItem(inlineResults);
 
                 hafasData.device()->seek(0x4a + partsOffset + iPart * 20);
 
@@ -571,7 +571,7 @@ void ParserHafasBinary::parseSearchJourney(QNetworkReply *networkReply)
 
                 lineNames.removeDuplicates();
 
-                JourneyResultItem *item = new JourneyResultItem();
+                JourneyResultItem *item = new JourneyResultItem(lastJourneyResultList);
                 item->setDate(journeyDate);
                 item->setId(connectionId);
                 item->setTransfers(QString::number(numChanges));

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -668,7 +668,7 @@ QString ParserHafasXml::parseExternalIds(const QVariant &id) const
 
 void ParserHafasXml::parseSearchJourney(QNetworkReply *networkReply)
 {
-    lastJourneyResultList = new JourneyResultList();
+    lastJourneyResultList = new JourneyResultList(this);
 
     QDomDocument doc;
     if (!parseXml(doc, networkReply->readAll()))

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -860,7 +860,7 @@ void ParserHafasXml::getJourneyDetails(const QString &id)
 
 JourneyDetailResultList* ParserHafasXml::internalParseJourneyDetails(const QDomElement &connection)
 {
-    JourneyDetailResultList *results = new JourneyDetailResultList();
+    JourneyDetailResultList *results = new JourneyDetailResultList(this);
 
     const QDomNodeList sections = connection.elementsByTagName("ConSection");
     for (int i = 0; i < sections.count(); ++i) {

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -32,7 +32,7 @@
 // http://stefanwehrmeyer.com/projects/vbbxsd/
 
 ParserHafasXml::ParserHafasXml(QObject *parent) :
-    ParserAbstract(parent)
+    ParserAbstract(parent), lastJourneyResultList(NULL)
 {
      //baseUrl = "http://fahrplan.oebb.at/bin/query.exe"; //OEB (fully operational/no RT) //no xmlhandle, detaildate already present!
      //baseUrl = "http://hafas.bene-system.com/bin/query.exe"; //hafas dev?? system? / no gps
@@ -48,8 +48,6 @@ ParserHafasXml::ParserHafasXml(QObject *parent) :
      hafasHeader.ver = "1.1";
 
      STTableMode = 0;
-
-     lastJourneyResultList = NULL;
 }
 
 ParserHafasXml::~ParserHafasXml()

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -767,6 +767,8 @@ void ParserHafasXml::searchJourneyLater()
 
     currentRequestState = FahrplanNS::searchJourneyLaterRequest;
 
+    clearJourney();
+
     QByteArray postData = "";
     postData.append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?><ReqC accessId=\"" + hafasHeader.accessid + "\" ver=\"" + hafasHeader.ver + "\" prod=\"" + hafasHeader.prod + "\" lang=\"EN\">");
     postData.append("<ConScrReq scrDir=\"F\" nrCons=\"5\">");
@@ -791,6 +793,8 @@ void ParserHafasXml::searchJourneyEarlier()
     }
 
     currentRequestState = FahrplanNS::searchJourneyEarlierRequest;
+
+    clearJourney();
 
     QByteArray postData = "";
     postData.append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?><ReqC accessId=\"" + hafasHeader.accessid + "\" ver=\"" + hafasHeader.ver + "\" prod=\"" + hafasHeader.prod + "\" lang=\"EN\">");

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -48,6 +48,26 @@ ParserHafasXml::ParserHafasXml(QObject *parent) :
      hafasHeader.ver = "1.1";
 
      STTableMode = 0;
+
+     lastJourneyResultList = NULL;
+}
+
+ParserHafasXml::~ParserHafasXml()
+{
+    cleanupJourney();
+}
+
+void ParserHafasXml::cleanupJourney()
+{
+    if (lastJourneyResultList) {
+        delete lastJourneyResultList;
+        lastJourneyResultList = NULL;
+    }
+
+    if (!journeyDetailInlineData.isEmpty()) {
+        qDeleteAll(journeyDetailInlineData);
+        journeyDetailInlineData.clear();
+    }
 }
 
 bool ParserHafasXml::supportsGps()
@@ -518,7 +538,8 @@ void ParserHafasXml::searchJourney(const Station &departureStation, const Statio
 
     currentRequestState = FahrplanNS::searchJourneyRequest;
     hafasContext.seqNr = "";
-    lastJourneyResultList = NULL;
+
+    cleanupJourney();
 
     QString trainrestr = getTrainRestrictionsCodes(trainrestrictions);
 
@@ -648,7 +669,6 @@ QString ParserHafasXml::parseExternalIds(const QVariant &id) const
 void ParserHafasXml::parseSearchJourney(QNetworkReply *networkReply)
 {
     lastJourneyResultList = new JourneyResultList();
-    journeyDetailInlineData.clear();
 
     QDomDocument doc;
     if (!parseXml(doc, networkReply->readAll()))

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -539,7 +539,11 @@ void ParserHafasXml::searchJourney(const Station &departureStation, const Statio
     currentRequestState = FahrplanNS::searchJourneyRequest;
     hafasContext.seqNr = "";
 
+<<<<<<< HEAD
     clearJourney();
+=======
+    cleanupJourney();
+>>>>>>> fixing leaks
 
     QString trainrestr = getTrainRestrictionsCodes(trainrestrictions);
 

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -54,10 +54,10 @@ ParserHafasXml::ParserHafasXml(QObject *parent) :
 
 ParserHafasXml::~ParserHafasXml()
 {
-    cleanupJourney();
+    clearJourney();
 }
 
-void ParserHafasXml::cleanupJourney()
+void ParserHafasXml::clearJourney()
 {
     if (lastJourneyResultList) {
         delete lastJourneyResultList;
@@ -539,7 +539,7 @@ void ParserHafasXml::searchJourney(const Station &departureStation, const Statio
     currentRequestState = FahrplanNS::searchJourneyRequest;
     hafasContext.seqNr = "";
 
-    cleanupJourney();
+    clearJourney();
 
     QString trainrestr = getTrainRestrictionsCodes(trainrestrictions);
 

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -539,11 +539,7 @@ void ParserHafasXml::searchJourney(const Station &departureStation, const Statio
     currentRequestState = FahrplanNS::searchJourneyRequest;
     hafasContext.seqNr = "";
 
-<<<<<<< HEAD
     clearJourney();
-=======
-    cleanupJourney();
->>>>>>> fixing leaks
 
     QString trainrestr = getTrainRestrictionsCodes(trainrestrictions);
 

--- a/src/parser/parser_hafasxml.cpp
+++ b/src/parser/parser_hafasxml.cpp
@@ -656,7 +656,7 @@ void ParserHafasXml::parseSearchJourney(QNetworkReply *networkReply)
 
     const QDomNodeList connections = doc.elementsByTagName("Connection");
     for (int i = 0; i < connections.count(); ++i) {
-        JourneyResultItem *item = new JourneyResultItem();
+        JourneyResultItem *item = new JourneyResultItem(lastJourneyResultList);
         item->setId(connections.at(i).toElement().attribute("id").trimmed());
 
         QDomElement overview = connections.at(i).firstChildElement("Overview");
@@ -846,7 +846,7 @@ JourneyDetailResultList* ParserHafasXml::internalParseJourneyDetails(const QDomE
 
     const QDomNodeList sections = connection.elementsByTagName("ConSection");
     for (int i = 0; i < sections.count(); ++i) {
-        JourneyDetailResultItem *item = new JourneyDetailResultItem();
+        JourneyDetailResultItem *item = new JourneyDetailResultItem(results);
 
         const QDomNode section = sections.at(i);
         QDomElement stop;

--- a/src/parser/parser_hafasxml.h
+++ b/src/parser/parser_hafasxml.h
@@ -75,6 +75,7 @@ public slots:
     bool supportsTimeTable();
     bool supportsTimeTableDirection();
     QStringList getTrainRestrictions();
+    virtual void clearJourney();
 
 protected:
     QString baseXmlUrl;
@@ -91,7 +92,6 @@ protected:
     void parseSearchLaterJourney(QNetworkReply *networkReply);
     void parseSearchEarlierJourney(QNetworkReply *networkReply);
     void parseJourneyDetails(QNetworkReply *networkReply);
-    void cleanupJourney();
     virtual QString getTrainRestrictionsCodes(int trainrestrictions);
 
     JourneyResultList *lastJourneyResultList;

--- a/src/parser/parser_hafasxml.h
+++ b/src/parser/parser_hafasxml.h
@@ -92,7 +92,6 @@ protected:
     void parseSearchLaterJourney(QNetworkReply *networkReply);
     void parseSearchEarlierJourney(QNetworkReply *networkReply);
     void parseJourneyDetails(QNetworkReply *networkReply);
-    void cleanupJourney();
     virtual QString getTrainRestrictionsCodes(int trainrestrictions);
 
     JourneyResultList *lastJourneyResultList;

--- a/src/parser/parser_hafasxml.h
+++ b/src/parser/parser_hafasxml.h
@@ -57,6 +57,7 @@ class ParserHafasXml : public ParserAbstract
     Q_OBJECT
 public:
     explicit ParserHafasXml(QObject *parent = 0);
+    virtual ~ParserHafasXml();
     static QString getName() { return "HafasXML"; }
     virtual QString name() { return getName(); }
     virtual QString shortName() { return getName(); }
@@ -90,6 +91,7 @@ protected:
     void parseSearchLaterJourney(QNetworkReply *networkReply);
     void parseSearchEarlierJourney(QNetworkReply *networkReply);
     void parseJourneyDetails(QNetworkReply *networkReply);
+    void cleanupJourney();
     virtual QString getTrainRestrictionsCodes(int trainrestrictions);
 
     JourneyResultList *lastJourneyResultList;

--- a/src/parser/parser_hafasxml.h
+++ b/src/parser/parser_hafasxml.h
@@ -92,6 +92,7 @@ protected:
     void parseSearchLaterJourney(QNetworkReply *networkReply);
     void parseSearchEarlierJourney(QNetworkReply *networkReply);
     void parseJourneyDetails(QNetworkReply *networkReply);
+    void cleanupJourney();
     virtual QString getTrainRestrictionsCodes(int trainrestrictions);
 
     JourneyResultList *lastJourneyResultList;

--- a/src/parser/parser_ninetwo.cpp
+++ b/src/parser/parser_ninetwo.cpp
@@ -185,6 +185,8 @@ void ParserNinetwo::searchJourney(const Station &departureStation,
 
     currentRequestState=FahrplanNS::searchJourneyRequest;
 
+    clearJourney();
+
 }
 
 void ParserNinetwo::searchJourneyLater()

--- a/src/parser/parser_ninetwo.cpp
+++ b/src/parser/parser_ninetwo.cpp
@@ -353,6 +353,18 @@ void ParserNinetwo::parseSearchJourney(QNetworkReply *networkReply)
         return;
     }
 
+    if (doc.contains("error")) {
+        QString error = doc.value("error").toString();
+        QString message;
+        if (error == "NoJourneys") {
+            message = tr("No connections have been found that correspond to your request.");
+        } else {
+            message = tr("Unknown error ocurred with the backend (error %1).").arg(error);
+        }
+        emit errorOccured(message);
+        return;
+    }
+
     QVariantList journeys = doc.value("journeys").toList();
 
     clearJourney();
@@ -370,9 +382,11 @@ void ParserNinetwo::parseSearchJourney(QNetworkReply *networkReply)
         arrival = QDateTime::fromString(journey.value("arrival").toString(), "yyyy-MM-ddTHH:mm");
         departure = QDateTime::fromString(journey.value("departure").toString(),
                                           "yyyy-MM-ddTHH:mm");
-        if (i == journeys.constBegin())
-            lastsearch.firstOption=departure;
+        if (i == journeys.constBegin()) {
+            lastsearch.firstOption = departure;
+        }
 
+        item->setDate(departure.date());
         item->setArrivalTime(arrival.toString("HH:mm"));
         item->setDepartureTime(departure.toString("HH:mm"));
 

--- a/src/parser/parser_ninetwo.cpp
+++ b/src/parser/parser_ninetwo.cpp
@@ -49,7 +49,7 @@ inline int distance(qreal lat1, qreal lon1, qreal lat2, qreal lon2)
     return qRound(6371.0 * c * 1000);
 }
 
-ParserNinetwo::ParserNinetwo(QObject *parent):ParserAbstract(parent)
+ParserNinetwo::ParserNinetwo(QObject *parent):ParserAbstract(parent), lastJourneyResultList(NULL)
 {
     lastCoordinates.isValid = false;
 }

--- a/src/parser/parser_ninetwo.cpp
+++ b/src/parser/parser_ninetwo.cpp
@@ -345,7 +345,7 @@ void ParserNinetwo::parseSearchJourney(QNetworkReply *networkReply)
     for (i = journeys.constBegin(); i != journeys.constEnd(); ++i) {
         QVariantMap journey = i->toMap();
         parseJourneyOption(journey);
-        JourneyResultItem* item = new JourneyResultItem;
+        JourneyResultItem* item = new JourneyResultItem(result);
         arrival = QDateTime::fromString(journey.value("arrival").toString(), "yyyy-MM-ddTHH:mm");
         departure = QDateTime::fromString(journey.value("departure").toString(),
                                           "yyyy-MM-ddTHH:mm");
@@ -424,7 +424,7 @@ void ParserNinetwo::parseJourneyOption(const QVariantMap &object)
     for(int i = 0; i < legs.count(); i++)
     {
         QVariantMap leg = legs.at(i).toMap();
-        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;
+        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem(result);
 
 
         QVariantList stops = leg.value("stops").toList();

--- a/src/parser/parser_ninetwo.cpp
+++ b/src/parser/parser_ninetwo.cpp
@@ -291,7 +291,7 @@ void ParserNinetwo::parseSearchJourney(QNetworkReply *networkReply)
     for (i = journeys.constBegin(); i != journeys.constEnd(); ++i) {
         QVariantMap journey = i->toMap();
         parseJourneyOption(journey);
-        JourneyResultItem* item = new JourneyResultItem;
+        JourneyResultItem* item = new JourneyResultItem(result);
         arrival = QDateTime::fromString(journey.value("arrival").toString(), "yyyy-MM-ddTHH:mm");
         departure = QDateTime::fromString(journey.value("departure").toString(),
                                           "yyyy-MM-ddTHH:mm");
@@ -373,7 +373,7 @@ void ParserNinetwo::parseJourneyOption(const QVariantMap &object)
     for(int i = 0; i < legs.count(); i++)
     {
         QVariantMap leg = legs.at(i).toMap();
-        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;
+        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem(result);
 
 
         QVariantList stops = leg.value("stops").toList();

--- a/src/parser/parser_ninetwo.h
+++ b/src/parser/parser_ninetwo.h
@@ -60,6 +60,7 @@ class ParserNinetwo : public ParserAbstract
 
 public:
     ParserNinetwo(QObject* parent = 0);
+    virtual ~ParserNinetwo();
 
     // ParserAbstract interface
 public:
@@ -80,6 +81,7 @@ public slots:
     bool supportsTimeTable() { return true; }
     bool supportsTimeTableDirection() { return false; }
     QStringList getTrainRestrictions();
+    virtual void clearJourney();
 
 protected:
     void parseTimeTable(QNetworkReply *networkReply);
@@ -90,6 +92,8 @@ protected:
     void parseSearchEarlierJourney(QNetworkReply *networkReply);
     void parseJourneyDetails(QNetworkReply *networkReply);
     QMap<QString, JourneyDetailResultList*> cachedResults;
+
+    JourneyResultList *lastJourneyResultList;
 
 private:
     void parseJourneyOption(const QVariantMap &object);

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -246,6 +246,9 @@ void ParserResRobot::searchJourney(const Station &departureStation, const Statio
     }
 
     currentRequestState = FahrplanNS::searchJourneyRequest;
+
+    clearJourney();
+
     numberOfUnsuccessfulEarlierSearches = 0;
     numberOfUnsuccessfulLaterSearches = 0;
     internalSearchJourney(departureStation, viaStation, arrivalStation, dateTime, mode, trainRestrictions);
@@ -263,6 +266,7 @@ void ParserResRobot::searchJourneyLater()
     }
 
     currentRequestState = FahrplanNS::searchJourneyLaterRequest;
+    clearJourney();
     internalSearchJourney(lastJourneySearch.from, lastJourneySearch.via, lastJourneySearch.to,
                           time, lastJourneySearch.mode, lastJourneySearch.restrictions);
 }
@@ -280,6 +284,7 @@ void ParserResRobot::searchJourneyEarlier()
     }
 
     currentRequestState = FahrplanNS::searchJourneyEarlierRequest;
+    clearJourney();
     internalSearchJourney(lastJourneySearch.from, lastJourneySearch.via, lastJourneySearch.to,
                           time, lastJourneySearch.mode, lastJourneySearch.restrictions);
 }
@@ -472,7 +477,6 @@ void ParserResRobot::parseSearchJourney(QNetworkReply *networkReply)
         journeyListData = ensureList(timetableResult.value("ttitem"));
     }
 
-    clearJourney();
     lastJourneyResultList = new JourneyResultList(this);
 
     int journeyCounter = 0;

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -27,6 +27,7 @@
 
 ParserResRobot::ParserResRobot(QObject *parent) :
         ParserAbstract(parent),
+        lastJourneyResultList(NULL),
         timetableAPIKey(QLatin1String("en9A5GyxZLB98ZYjX8rkSNyHkurGb81G")),
         journeyAPIKey(QLatin1String("gcyYB9moXYXOTY2dAb06k7GAAOiZVXZr")),
         timetableBaseURL(QLatin1String("https://api.trafiklab.se/samtrafiken/resrobotstops/")),

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -537,15 +537,7 @@ QList<JourneyDetailResultItem*> ParserResRobot::parseJourneySegments(const QVari
     foreach (QVariant segmentData, segments)
     {
         QVariantMap segment = segmentData.toMap();
-<<<<<<< HEAD
-<<<<<<< HEAD
         JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;//FIXME will leak in QML
-=======
-        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem(results);
->>>>>>> added missed parents
-=======
-        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;//FIXME will leak in QML
->>>>>>> not that easy there, leaving a FIXME for the next round
 
         // Departure
         QVariantMap departure = segment.value("departure").toMap();

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -537,7 +537,11 @@ QList<JourneyDetailResultItem*> ParserResRobot::parseJourneySegments(const QVari
     foreach (QVariant segmentData, segments)
     {
         QVariantMap segment = segmentData.toMap();
+<<<<<<< HEAD
         JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;//FIXME will leak in QML
+=======
+        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem(results);
+>>>>>>> added missed parents
 
         // Departure
         QVariantMap departure = segment.value("departure").toMap();

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -479,7 +479,7 @@ void ParserResRobot::parseSearchJourney(QNetworkReply *networkReply)
         else if (arrDayDiff < 0)
             arrTime += QString::number(arrDayDiff);
 
-        JourneyResultItem* journey = new JourneyResultItem(result);
+        JourneyResultItem* journey = new JourneyResultItem(journeyList);
         journey->setId(journeyID);
         journey->setDate(segments.first()->departureDateTime().date());
         journey->setDepartureTime(depTime);
@@ -523,7 +523,7 @@ QList<JourneyDetailResultItem*> ParserResRobot::parseJourneySegments(const QVari
     foreach (QVariant segmentData, segments)
     {
         QVariantMap segment = segmentData.toMap();
-        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem(results);
+        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;//FIXME will leak in QML
 
         // Departure
         QVariantMap departure = segment.value("departure").toMap();

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -479,7 +479,7 @@ void ParserResRobot::parseSearchJourney(QNetworkReply *networkReply)
         else if (arrDayDiff < 0)
             arrTime += QString::number(arrDayDiff);
 
-        JourneyResultItem* journey = new JourneyResultItem;
+        JourneyResultItem* journey = new JourneyResultItem(result);
         journey->setId(journeyID);
         journey->setDate(segments.first()->departureDateTime().date());
         journey->setDepartureTime(depTime);
@@ -523,7 +523,7 @@ QList<JourneyDetailResultItem*> ParserResRobot::parseJourneySegments(const QVari
     foreach (QVariant segmentData, segments)
     {
         QVariantMap segment = segmentData.toMap();
-        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;
+        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem(results);
 
         // Departure
         QVariantMap departure = segment.value("departure").toMap();

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -538,10 +538,14 @@ QList<JourneyDetailResultItem*> ParserResRobot::parseJourneySegments(const QVari
     {
         QVariantMap segment = segmentData.toMap();
 <<<<<<< HEAD
+<<<<<<< HEAD
         JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;//FIXME will leak in QML
 =======
         JourneyDetailResultItem* resultItem = new JourneyDetailResultItem(results);
 >>>>>>> added missed parents
+=======
+        JourneyDetailResultItem* resultItem = new JourneyDetailResultItem;//FIXME will leak in QML
+>>>>>>> not that easy there, leaving a FIXME for the next round
 
         // Departure
         QVariantMap departure = segment.value("departure").toMap();

--- a/src/parser/parser_resrobot.h
+++ b/src/parser/parser_resrobot.h
@@ -127,7 +127,7 @@ private:
     const int nearbyRadius; // Define what is "nearby" in meters
     const int timetableSpan; // Minutes (valid values: 30 or 120)
     bool realtime;
-    QMap<QString, JourneyDetailResultList*> cachedResults;
+    QHash<QString, JourneyDetailResultList*> cachedResults;
     // Keep track of the number of "earlier"/"later" searches we did without getting any new results
     int numberOfUnsuccessfulEarlierSearches;
     int numberOfUnsuccessfulLaterSearches;

--- a/src/parser/parser_resrobot.h
+++ b/src/parser/parser_resrobot.h
@@ -60,6 +60,7 @@ class ParserResRobot : public ParserAbstract
     Q_OBJECT
 public:
     explicit ParserResRobot(QObject *parent = 0);
+    virtual ~ParserResRobot();
 
     static QString getName() { return QString("%1 (resrobot.se)").arg(tr("Sweden")); }
     virtual QString name() { return getName(); }
@@ -84,6 +85,7 @@ public slots:
     virtual void searchJourneyLater();
     virtual void searchJourneyEarlier();
     virtual void getJourneyDetails(const QString &id);
+    virtual void clearJourney();
 
 protected:
     virtual void parseTimeTable(QNetworkReply *networkReply);
@@ -93,6 +95,8 @@ protected:
     virtual void parseSearchLaterJourney(QNetworkReply *networkReply);
     virtual void parseSearchEarlierJourney(QNetworkReply *networkReply);
     virtual void parseJourneyDetails(QNetworkReply *networkReply);
+
+    JourneyResultList *lastJourneyResultList;
 
 private:
     enum transportModePreset {

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -483,7 +483,7 @@ void ParserXmlVasttrafikSe::searchJourneyLater()
         searchJourney(m_searchJourneyParameters.departureStation, m_searchJourneyParameters.arrivalStation, m_searchJourneyParameters.viaStation, m_latestResultDeparture, Departure, 0);
     else {
         clearJourney();
-        lastJourneyResultList = new JourneyResultList();
+        lastJourneyResultList = new JourneyResultList(this);
         lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
         lastJourneyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
         lastJourneyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
@@ -499,7 +499,7 @@ void ParserXmlVasttrafikSe::searchJourneyEarlier()
         searchJourney(m_searchJourneyParameters.departureStation, m_searchJourneyParameters.arrivalStation, m_searchJourneyParameters.viaStation, m_earliestArrival, Arrival, 0);
     else {
         clearJourney();
-        lastJourneyResultList = new JourneyResultList();
+        lastJourneyResultList = new JourneyResultList(this);
         lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
         lastJourneyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
         lastJourneyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -160,6 +160,8 @@ void ParserXmlVasttrafikSe::searchJourney(const Station &departureStation, const
         return;
     currentRequestState = FahrplanNS::searchJourneyRequest;
 
+    clearJourney();
+
     m_searchJourneyParameters.isValid = false;
     m_searchJourneyParameters.departureStation = departureStation;
     m_searchJourneyParameters.arrivalStation = arrivalStation;
@@ -323,7 +325,6 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
 {
     qDebug() << "ParserXmlVasttrafikSe::parseSearchJourney(networkReply.url()=" << networkReply->url().toString() << ")";
 
-    clearJourney();
     lastJourneyResultList = new JourneyResultList(this);
 
     /// Use fallback values for empty results (i.e. no connections found)

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -40,7 +40,7 @@ QHash<QString, JourneyDetailResultList *> cachedJourneyDetails;
 #define getAttribute(node, key) (node.attributes().namedItem(key).toAttr().value())
 
 ParserXmlVasttrafikSe::ParserXmlVasttrafikSe(QObject *parent)
-    : ParserAbstract(parent), apiKey(QLatin1String("47c5abaf-49d6-4c23-a1bd-b2e2766c4de7")), baseRestUrl(QLatin1String("http://api.vasttrafik.se/bin/rest.exe/v1/"))
+    : ParserAbstract(parent), lastJourneyResultList(NULL), apiKey(QLatin1String("47c5abaf-49d6-4c23-a1bd-b2e2766c4de7")), baseRestUrl(QLatin1String("http://api.vasttrafik.se/bin/rest.exe/v1/"))
 {
     m_searchJourneyParameters.isValid = false;
     m_timeTableForStationParameters.isValid = false;

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -46,6 +46,18 @@ ParserXmlVasttrafikSe::ParserXmlVasttrafikSe(QObject *parent)
     m_timeTableForStationParameters.isValid = false;
 }
 
+ParserXmlVasttrafikSe::~ParserXmlVasttrafikSe()
+{
+    clearJourney();
+}
+
+void ParserXmlVasttrafikSe::clearJourney()
+{
+    if (lastJourneyResultList) {
+        delete lastJourneyResultList;
+        lastJourneyResultList = NULL;
+    }
+}
 
 void ParserXmlVasttrafikSe::getTimeTableForStation(const Station &currentStation, const Station &, const QDateTime &dateTime, Mode mode, int)
 {
@@ -305,7 +317,8 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
 {
     qDebug() << "ParserXmlVasttrafikSe::parseSearchJourney(networkReply.url()=" << networkReply->url().toString() << ")";
 
-    JourneyResultList *journeyResultList = new JourneyResultList();
+    clearJourney();
+    lastJourneyResultList = new JourneyResultList(this);
 
     for (QHash<QString, JourneyDetailResultList *>::Iterator it = cachedJourneyDetails.begin(); it != cachedJourneyDetails.end();) {
         JourneyDetailResultList *jdrl = it.value();
@@ -314,11 +327,11 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
     }
 
     /// Use fallback values for empty results (i.e. no connections found)
-    journeyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
-    journeyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
-    journeyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
+    lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
+    lastJourneyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
+    lastJourneyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
     //: DATE, TIME
-    journeyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
+    lastJourneyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
 
     m_earliestArrival = m_latestResultDeparture = QDateTime();
 
@@ -329,8 +342,8 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
     if (doc.setContent(xmlRawtext, false)) {
         QDomNodeList tripNodeList = doc.elementsByTagName("Trip");
         for (unsigned int i = 0; i < tripNodeList.length(); ++i) {
-            JourneyResultItem *jritem = new JourneyResultItem(journeyResultList);
-            JourneyDetailResultList *detailsList = new JourneyDetailResultList();
+            JourneyResultItem *jritem = new JourneyResultItem(lastJourneyResultList);
+            JourneyDetailResultList *detailsList = new JourneyDetailResultList(this);
 
             /// Set default values for journey's start and end time
             QDateTime journeyStart = QDateTime::currentDateTime();
@@ -351,15 +364,15 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
                     journeyStart.setTime(time);
                     if (i == 0) {
                         const QDate date = QDate::fromString(getAttribute(originNode, "date"), QLatin1String("yyyy-MM-dd"));
-                        journeyResultList->setDepartureStation(getAttribute(originNode, "name"));
+                        lastJourneyResultList->setDepartureStation(getAttribute(originNode, "name"));
                         //: DATE, TIME
-                        journeyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(date.toString(Qt::DefaultLocaleShortDate)).arg(time.toString(Qt::DefaultLocaleShortDate)));
+                        lastJourneyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(date.toString(Qt::DefaultLocaleShortDate)).arg(time.toString(Qt::DefaultLocaleShortDate)));
                     }
                 }
                 if (j == legNodeList.length() - 1) {
                     journeyEnd.setTime(QTime::fromString(getAttribute(destinationNode, "time"), "hh:mm"));
                     if (i == 0)
-                        journeyResultList->setArrivalStation(getAttribute(destinationNode, "name"));
+                        lastJourneyResultList->setArrivalStation(getAttribute(destinationNode, "name"));
                 }
 
                 if (getAttribute(legNode, "type") != QLatin1String("WALK") || getAttribute(originNode, "name") != getAttribute(destinationNode, "name")) {
@@ -441,14 +454,14 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
             else if (tripRtStatus == TRIP_RTDATA_ONTIME)
                 jritem->setMiscInfo(tr("<span style=\"color:#093; font-weight: normal;\">on time</span>"));
 
-            journeyResultList->appendItem(jritem);
+            lastJourneyResultList->appendItem(jritem);
 
             const QString id = QString::number(i);
             jritem->setId(id);
             detailsList->setId(id);
-            detailsList->setDepartureStation(journeyResultList->departureStation());
-            detailsList->setViaStation(journeyResultList->viaStation());
-            detailsList->setArrivalStation(journeyResultList->arrivalStation());
+            detailsList->setDepartureStation(lastJourneyResultList->departureStation());
+            detailsList->setViaStation(lastJourneyResultList->viaStation());
+            detailsList->setArrivalStation(lastJourneyResultList->arrivalStation());
             detailsList->setDuration(jritem->duration());
             detailsList->setArrivalDateTime(journeyEnd);
             detailsList->setDepartureDateTime(journeyStart);
@@ -461,7 +474,7 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
         }
     }
 
-    emit journeyResult(journeyResultList);
+    emit journeyResult(lastJourneyResultList);
 }
 
 void ParserXmlVasttrafikSe::searchJourneyLater()
@@ -469,13 +482,14 @@ void ParserXmlVasttrafikSe::searchJourneyLater()
     if (m_latestResultDeparture.isValid())
         searchJourney(m_searchJourneyParameters.departureStation, m_searchJourneyParameters.arrivalStation, m_searchJourneyParameters.viaStation, m_latestResultDeparture, Departure, 0);
     else {
-        JourneyResultList *journeyResultList = new JourneyResultList();
-        journeyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
-        journeyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
-        journeyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
+        clearJourney();
+        lastJourneyResultList = new JourneyResultList();
+        lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
+        lastJourneyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
+        lastJourneyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
         //: DATE, TIME
-        journeyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
-        emit journeyResult(journeyResultList);
+        lastJourneyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
+        emit journeyResult(lastJourneyResultList);
     }
 }
 
@@ -484,13 +498,14 @@ void ParserXmlVasttrafikSe::searchJourneyEarlier()
     if (m_earliestArrival.isValid())
         searchJourney(m_searchJourneyParameters.departureStation, m_searchJourneyParameters.arrivalStation, m_searchJourneyParameters.viaStation, m_earliestArrival, Arrival, 0);
     else {
-        JourneyResultList *journeyResultList = new JourneyResultList();
-        journeyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
-        journeyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
-        journeyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
+        clearJourney();
+        lastJourneyResultList = new JourneyResultList();
+        lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);
+        lastJourneyResultList->setViaStation(m_searchJourneyParameters.viaStation.name);
+        lastJourneyResultList->setArrivalStation(m_searchJourneyParameters.arrivalStation.name);
         //: DATE, TIME
-        journeyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
-        emit journeyResult(journeyResultList);
+        lastJourneyResultList->setTimeInfo(tr("%1, %2", "DATE, TIME").arg(m_searchJourneyParameters.dateTime.date().toString(Qt::DefaultLocaleShortDate)).arg(m_searchJourneyParameters.dateTime.time().toString(Qt::DefaultLocaleShortDate)));
+        emit journeyResult(lastJourneyResultList);
     }
 }
 

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -57,6 +57,12 @@ void ParserXmlVasttrafikSe::clearJourney()
         delete lastJourneyResultList;
         lastJourneyResultList = NULL;
     }
+
+    for (QHash<QString, JourneyDetailResultList *>::Iterator it = cachedJourneyDetails.begin(); it != cachedJourneyDetails.end();) {
+        JourneyDetailResultList *jdrl = it.value();
+        it = cachedJourneyDetails.erase(it);
+        delete jdrl;
+    }
 }
 
 void ParserXmlVasttrafikSe::getTimeTableForStation(const Station &currentStation, const Station &, const QDateTime &dateTime, Mode mode, int)
@@ -319,12 +325,6 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
 
     clearJourney();
     lastJourneyResultList = new JourneyResultList(this);
-
-    for (QHash<QString, JourneyDetailResultList *>::Iterator it = cachedJourneyDetails.begin(); it != cachedJourneyDetails.end();) {
-        JourneyDetailResultList *jdrl = it.value();
-        it = cachedJourneyDetails.erase(it);
-        delete jdrl;
-    }
 
     /// Use fallback values for empty results (i.e. no connections found)
     lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -325,6 +325,15 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
 
     clearJourney();
     lastJourneyResultList = new JourneyResultList(this);
+<<<<<<< HEAD
+=======
+
+    for (QHash<QString, JourneyDetailResultList *>::Iterator it = cachedJourneyDetails.begin(); it != cachedJourneyDetails.end();) {
+        JourneyDetailResultList *jdrl = it.value();
+        it = cachedJourneyDetails.erase(it);
+        delete jdrl;
+    }
+>>>>>>> fixing ParserXmlVasttrafikSe memory leaks
 
     /// Use fallback values for empty results (i.e. no connections found)
     lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -329,7 +329,7 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
     if (doc.setContent(xmlRawtext, false)) {
         QDomNodeList tripNodeList = doc.elementsByTagName("Trip");
         for (unsigned int i = 0; i < tripNodeList.length(); ++i) {
-            JourneyResultItem *jritem = new JourneyResultItem();
+            JourneyResultItem *jritem = new JourneyResultItem(journeyResultList);
             JourneyDetailResultList *detailsList = new JourneyDetailResultList();
 
             /// Set default values for journey's start and end time
@@ -367,7 +367,7 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
                     trainTypes.append(i18nConnectionType(getAttribute(legNode, "name")));
                 }
 
-                JourneyDetailResultItem *jdrItem = new JourneyDetailResultItem();
+                JourneyDetailResultItem *jdrItem = new JourneyDetailResultItem(detailsList);
                 jdrItem->setDepartureStation(getAttribute(originNode, "name"));
                 const QString depTrack = getAttribute(originNode, "track");
                 jdrItem->setDepartureInfo(depTrack.isEmpty() ? QChar(0x2014) : tr("Track %1").arg(depTrack));

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -325,15 +325,6 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
 
     clearJourney();
     lastJourneyResultList = new JourneyResultList(this);
-<<<<<<< HEAD
-=======
-
-    for (QHash<QString, JourneyDetailResultList *>::Iterator it = cachedJourneyDetails.begin(); it != cachedJourneyDetails.end();) {
-        JourneyDetailResultList *jdrl = it.value();
-        it = cachedJourneyDetails.erase(it);
-        delete jdrl;
-    }
->>>>>>> fixing ParserXmlVasttrafikSe memory leaks
 
     /// Use fallback values for empty results (i.e. no connections found)
     lastJourneyResultList->setDepartureStation(m_searchJourneyParameters.departureStation.name);

--- a/src/parser/parser_xmlvasttrafikse.h
+++ b/src/parser/parser_xmlvasttrafikse.h
@@ -28,6 +28,7 @@ class ParserXmlVasttrafikSe : public ParserAbstract
 
 public:
     explicit ParserXmlVasttrafikSe(QObject *parent = 0);
+    virtual ~ParserXmlVasttrafikSe();
     static QString getName() { return QString("%1 (vasttrafik.se)").arg(tr("Sweden")); }
     virtual QString name() { return getName(); }
     virtual QString shortName() { return "vasttrafik.se"; }
@@ -46,12 +47,15 @@ public slots:
     virtual bool supportsTimeTableDirection();
 //     virtual QStringList getTrainRestrictions();
 //     void cancelRequest();
+    virtual void clearJourney();
 
 protected:
     virtual void parseStationsByName(QNetworkReply *networkReply);
     virtual void parseStationsByCoordinates(QNetworkReply *networkReply);
     virtual void parseTimeTable(QNetworkReply *networkReply);
     virtual void parseSearchJourney(QNetworkReply *networkReply);
+
+    JourneyResultList *lastJourneyResultList;
 
 private:
     static const qlonglong TRIP_RTDATA_NONE;


### PR DESCRIPTION
Due to returning QObject\* in calls to C++ objects from QML (e.g.
getItem(i)), those objects were changing ownership to QML and were
subject to gc. That could've been noticed during switching between
journey results and journey details results (instantly switch back and
forth to create enough garbage).
`var item = result.getItem(i);`
`item` would be null after some time. So it was ending up in page
showing loader and not doing anything or in a bit more rare cases with
segfault.
