### PR TITLE
Added support for miscinfo in the stationselect page and improved timetable results page

### DIFF
--- a/src/gui/ubuntu/AboutPage.qml
+++ b/src/gui/ubuntu/AboutPage.qml
@@ -20,7 +20,6 @@
 import QtQuick 2.4
 import Ubuntu.Components 1.2
 import Ubuntu.Components.Popups 1.0
-import Ubuntu.Components.ListItems 1.0 as ListItem
 import Fahrplan 1.0
 import "../about.js" as About
 

--- a/src/gui/ubuntu/AboutPage.qml
+++ b/src/gui/ubuntu/AboutPage.qml
@@ -17,8 +17,8 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.3
-import Ubuntu.Components 1.1
+import QtQuick 2.4
+import Ubuntu.Components 1.2
 import Ubuntu.Components.Popups 1.0
 import Ubuntu.Components.ListItems 1.0 as ListItem
 import Fahrplan 1.0

--- a/src/gui/ubuntu/JourneyDetailsResultsPage.qml
+++ b/src/gui/ubuntu/JourneyDetailsResultsPage.qml
@@ -17,9 +17,9 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.1
+import Ubuntu.Components 1.2
 import Fahrplan 1.0
 import "components"
 

--- a/src/gui/ubuntu/JourneyResultsPage.qml
+++ b/src/gui/ubuntu/JourneyResultsPage.qml
@@ -18,8 +18,8 @@
 ****************************************************************************/
 
 import Fahrplan 1.0
-import QtQuick 2.3
-import Ubuntu.Components 1.1
+import QtQuick 2.4
+import Ubuntu.Components 1.2
 import "components"
 
 Page {

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -17,8 +17,8 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.3
-import Ubuntu.Components 1.1
+import QtQuick 2.4
+import Ubuntu.Components 1.2
 import Ubuntu.Components.Popups 1.0
 import Ubuntu.Components.ListItems 1.0 as ListItems
 import "components"
@@ -144,9 +144,6 @@ Page {
 
                 onClicked: {
                     mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
-                    mainStack.currentPage.stationSelected.connect(function() {
-                        mainStack.pop();
-                    })
                 }
 
                 onPressAndHold: openMenu(departureButton)
@@ -162,9 +159,6 @@ Page {
 
                 onClicked: {
                     mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
-                    mainStack.currentPage.stationSelected.connect(function() {
-                        mainStack.pop();
-                    })
                 }
 
                 onPressAndHold: openMenu(viaButton)
@@ -180,9 +174,6 @@ Page {
 
                 onClicked: {
                     mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: type, title: text})
-                    mainStack.currentPage.stationSelected.connect(function() {
-                        mainStack.pop();
-                    })
                 }
 
                 onPressAndHold: openMenu(arrivalButton)
@@ -196,9 +187,6 @@ Page {
 
                 onClicked: {
                     mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: FahrplanBackend.CurrentStation, title: text})
-                    mainStack.currentPage.stationSelected.connect(function() {
-                        mainStack.pop();
-                    })
                 }
             }
 
@@ -210,9 +198,6 @@ Page {
 
                 onClicked: {
                     mainStack.push("qrc:///src/gui/ubuntu/components/StationSelect.qml", {type: FahrplanBackend.DirectionStation})
-                    mainStack.currentPage.stationSelected.connect(function() {
-                        mainStack.pop();
-                    })
                 }
 
                 onPressAndHold: timeTableSelectContextMenu.open()

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -256,8 +256,8 @@ Page {
             }
 
 
-            ListItems.Standard {
-                showDivider: false
+            ListItem {
+                divider.visible: false
                 height: units.gu(8)
                 Button {
                     id: timetableSearch
@@ -300,7 +300,7 @@ Page {
     Component {
         id: selectBackendComponent
         Dialog {
-            title: qsTr("Select backend")
+            title: qsTr("<b>Select backend</b>")
             id: selectBackendDialog
             contents: [
                 ListView {
@@ -335,7 +335,7 @@ Page {
 
         Dialog {
             id: selectTrainrestrictionsDialog
-            title: qsTr("Select train")
+            title: qsTr("<b>Select transport mode</b>")
             ListView {
                 width: parent.width
                 height: contentHeight

--- a/src/gui/ubuntu/SettingsPage.qml
+++ b/src/gui/ubuntu/SettingsPage.qml
@@ -17,8 +17,8 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.3
-import Ubuntu.Components 1.1
+import QtQuick 2.4
+import Ubuntu.Components 1.2
 import Ubuntu.Components.ListItems 0.1 as ListItems
 import Fahrplan 1.0
 import "components"

--- a/src/gui/ubuntu/TimeTableResultsPage.qml
+++ b/src/gui/ubuntu/TimeTableResultsPage.qml
@@ -19,8 +19,9 @@
 
 import Fahrplan 1.0
 import QtQuick 2.3
+import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.1
-import Ubuntu.Components.ListItems 0.1 as ListItems
+import Ubuntu.Components.ListItems 1.0 as ListItems
 import "components"
 
 Page {
@@ -39,112 +40,109 @@ Page {
         }
     }
 
-    Item {
-        id: searchResults
+    ActivityIndicator {
+        id: searchIndicator
+        anchors.centerIn: parent
+        running: true
+        visible: false
+    }
 
+    ListView {
+        id: listView
+        clip: true
         anchors.fill: parent
-
-        ActivityIndicator {
-            id: searchIndicator
-            anchors.centerIn: parent
-            running: true
-            visible: false
-        }
-
-        ListView {
-            id: listView
-            clip: true
-            anchors.fill: parent
-            model: fahrplanBackend.timetable
-            delegate:  timetableResultDelegate
-        }
+        model: fahrplanBackend.timetable
+        delegate:  timetableResultDelegate
     }
 
     Component {
         id: timetableResultDelegate
 
-        ListItems.Base {
+        ListItems.Empty {
             id: delegateItem
+
             width: listView.width
-            height: units.gu(4) + lbl_destination.height + (lbl_station.height > lbl_type.height ? lbl_station.height : lbl_type.height) + (lbl_miscinfo.visible ? lbl_miscinfo.height : 0)
+            height: units.gu(2) + mainColumn.height
             highlightWhenPressed: false
 
-            Item {
-                anchors {
-                    verticalCenter: parent.verticalCenter
-                    top: parent.top
-                    topMargin: units.gu(1)
+            Column {
+                id: mainColumn
+
+                anchors { verticalCenter: parent.verticalCenter; left: parent.left; right: parent.right; leftMargin: units.gu(2); rightMargin: units.gu(2) }
+
+                RowLayout {
+                    id: mainLayout
+
+                    spacing: units.gu(1)
+                    height: Math.max(leftColumn.height, rightColumn.height)
+                    width: parent.width
+
+                    Column {
+                        id: leftColumn
+
+                        Layout.preferredWidth: units.gu(8)
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        Label {
+                            id: lbl_time
+                            text: Qt.formatTime(model.time, Qt.DefaultLocaleShortDate)
+                            font.bold: true
+                        }
+
+                        Label {
+                            id: lbl_type
+                            text: model.trainType
+                            fontSize: "x-small"
+                        }
+                    }
+
+                    Column {
+                        id: rightColumn
+
+                        Layout.fillWidth: true
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        Label {
+                            id: lbl_destination
+                            text: model.destinationStation
+                            elide: Text.ElideRight
+                            font.bold: true
+                            horizontalAlignment: Text.AlignLeft
+                            width: parent.width
+                        }
+
+                        Label {
+                            id: lbl_station
+                            text: {
+                                var platform;
+                                if (model.platform) {
+                                    platform = qsTr("Pl. %1").arg(model.platform);
+                                    if (model.currentStation) {
+                                        platform += " / " + model.currentStation;
+                                    }
+                                } else {
+                                    platform = model.currentStation;
+                                }
+                                return platform;
+                            }
+                            width: parent.width
+                            fontSize: "x-small"
+                            visible: text !== ""
+                        }
+                    }
                 }
 
-                width: parent.width
-                height: parent.height
-
-                Grid {
-                    columns: 2
-                    spacing: units.gu(1)
-
-                    anchors {
-                        leftMargin: units.gu(1)
-                        left: parent.left
-                    }
-
+                Label {
+                    id: lbl_miscinfo
+                    visible: miscInfo !== ""
+                    text: miscInfo
                     width: parent.width
-                    height: parent.height
-
-                    Label {
-                        id: lbl_time
-                        text: Qt.formatTime(model.time, Qt.DefaultLocaleShortDate)
-                        font.bold: true
-                        width: (parent.width  - units.gu(4)) / 4
-                    }
-
-                    Label {
-                        id: lbl_destination
-                        text: "%1 <b>%2</b>".arg(fahrplanBackend.mode === FahrplanBackend.ArrivalMode ? qsTr("from") : qsTr("to")).arg(model.destinationStation)
-                        width: ((parent.width  - units.gu(4)) / 4) * 3
-                        elide: Text.ElideRight
-                    }
-
-                    Label {
-                        id: lbl_type
-                        text: model.trainType
-                        font.bold: true
-                        width: (parent.width  - units.gu(4)) / 4
-                    }
-
-                    Label {
-                        id: lbl_station
-                        text: {
-                            var platform;
-                            if (model.platform) {
-                                platform = qsTr("Pl. %1").arg(model.platform);
-                                if (model.currentStation) {
-                                    platform += " / " + model.currentStation;
-                                }
-                            } else {
-                                platform = model.currentStation;
-                            }
-                            return platform;
-                        }
-                        width: ((parent.width  - units.gu(4)) / 4) * 3
-                    }
-
-                    Label {
-                        id: lbl_miscinfo_title
-                        visible: (miscInfo == "") ? false : true
-                        text: ""
-                        width: (parent.width  - units.gu(4)) / 4
-                        elide: Text.ElideRight
-                    }
-
-                    Label {
-                        id: lbl_miscinfo
-                        visible: (miscInfo == "") ? false : true
-                        text: miscInfo
-                        width: ((parent.width  - units.gu(4)) / 4)  * 3
-                        font.bold: true
-                        elide: Text.ElideRight
-                    }
+                    fontSize: "small"
+                    elide: Text.ElideRight
+                    wrapMode: Text.WordWrap
+                    maximumLineCount: 2
+                    font.italic: true
+                    textFormat: Text.RichText
                 }
             }
         }

--- a/src/gui/ubuntu/TimeTableResultsPage.qml
+++ b/src/gui/ubuntu/TimeTableResultsPage.qml
@@ -21,7 +21,6 @@ import Fahrplan 1.0
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.2
-import Ubuntu.Components.ListItems 1.0 as ListItems
 import "components"
 
 Page {
@@ -58,12 +57,12 @@ Page {
     Component {
         id: timetableResultDelegate
 
-        ListItems.Empty {
+        ListItem {
             id: delegateItem
 
             width: listView.width
             height: units.gu(2) + mainColumn.height
-            highlightWhenPressed: false
+            highlightColor: "Transparent"
 
             Column {
                 id: mainColumn

--- a/src/gui/ubuntu/TimeTableResultsPage.qml
+++ b/src/gui/ubuntu/TimeTableResultsPage.qml
@@ -18,9 +18,9 @@
 ****************************************************************************/
 
 import Fahrplan 1.0
-import QtQuick 2.3
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.1
+import Ubuntu.Components 1.2
 import Ubuntu.Components.ListItems 1.0 as ListItems
 import "components"
 

--- a/src/gui/ubuntu/components/CustomListItem.qml
+++ b/src/gui/ubuntu/components/CustomListItem.qml
@@ -22,7 +22,7 @@ ListItem {
             id: _value
             elide: Text.ElideMiddle
             horizontalAlignment: Text.AlignRight
-            Layout.maximumWidth: parent.width - _title.implicitWidth - _progression.width
+            Layout.maximumWidth: parent.width - _title.implicitWidth - _progression.width - units.gu(2)
         }
 
         Icon {

--- a/src/gui/ubuntu/components/CustomListItem.qml
+++ b/src/gui/ubuntu/components/CustomListItem.qml
@@ -1,9 +1,8 @@
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.2
-import Ubuntu.Components.ListItems 1.0 as ListItem
 
-ListItem.Base {
+ListItem {
     id: customListItem
 
     property alias text: _title.text
@@ -11,7 +10,7 @@ ListItem.Base {
 
     RowLayout {
         spacing: units.gu(1)
-        anchors { left: parent.left; right: parent.right; verticalCenter: parent.verticalCenter }
+        anchors { left: parent.left; right: parent.right; verticalCenter: parent.verticalCenter; margins: units.gu(2) }
 
         Label {
             id: _title

--- a/src/gui/ubuntu/components/CustomListItem.qml
+++ b/src/gui/ubuntu/components/CustomListItem.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.3
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.1
+import Ubuntu.Components 1.2
 import Ubuntu.Components.ListItems 1.0 as ListItem
 
 ListItem.Base {

--- a/src/gui/ubuntu/components/DatePicker.qml
+++ b/src/gui/ubuntu/components/DatePicker.qml
@@ -17,8 +17,8 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.3
-import Ubuntu.Components 1.1
+import QtQuick 2.4
+import Ubuntu.Components 1.2
 import Ubuntu.Components.Popups 1.0
 import Ubuntu.Components.Pickers 1.0
 

--- a/src/gui/ubuntu/components/StationSelect.qml
+++ b/src/gui/ubuntu/components/StationSelect.qml
@@ -23,7 +23,6 @@ import QtLocation 5.0
 import QtPositioning 5.2
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.2
-import Ubuntu.Components.ListItems 1.0 as ListItems
 import "."
 import ".."
 
@@ -116,7 +115,7 @@ Page {
         width: parent.width
         model: stationSelect.showFavorites ? fahrplanBackend.favorites : fahrplanBackend.stationSearchResults
 
-        delegate: ListItems.Empty {
+        delegate: ListItem {
             id: delegateItem
 
             RowLayout {

--- a/src/gui/ubuntu/components/StationSelect.qml
+++ b/src/gui/ubuntu/components/StationSelect.qml
@@ -18,11 +18,11 @@
 ****************************************************************************/
 
 import Fahrplan 1.0
-import QtQuick 2.3
+import QtQuick 2.4
 import QtLocation 5.0
 import QtPositioning 5.2
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.1
+import Ubuntu.Components 1.2
 import Ubuntu.Components.ListItems 1.0 as ListItems
 import "."
 import ".."
@@ -161,6 +161,7 @@ Page {
             onClicked: {
                 listView.model.selectStation(stationSelect.type, model.index);
                 stationSelect.stationSelected()
+                mainStack.pop()
             }
         }
     }

--- a/src/gui/ubuntu/components/StationSelect.qml
+++ b/src/gui/ubuntu/components/StationSelect.qml
@@ -21,6 +21,7 @@ import Fahrplan 1.0
 import QtQuick 2.3
 import QtLocation 5.0
 import QtPositioning 5.2
+import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.1
 import Ubuntu.Components.ListItems 1.0 as ListItems
 import "."
@@ -115,31 +116,51 @@ Page {
         width: parent.width
         model: stationSelect.showFavorites ? fahrplanBackend.favorites : fahrplanBackend.stationSearchResults
 
-        delegate: ListItems.Standard {
+        delegate: ListItems.Empty {
             id: delegateItem
 
-            text: name
-            iconFrame: false
-            iconName: model.isFavorite ? "starred" : "non-starred"
+            RowLayout {
+                id: rowLayout
+                spacing: units.gu(2)
+                anchors { verticalCenter: parent.verticalCenter; left: parent.left; right: parent.right; margins: units.gu(2) }
+
+                Icon {
+                    id: favoriteIcon
+                    name: model.isFavorite ? "starred" : "non-starred"
+                    width: units.gu(4)
+                    height: width
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            if (model.isFavorite) {
+                                listView.model.removeFromFavorites(index);
+                                favoriteIcon.name = "non-starred";
+                            } else {
+                                listView.model.addToFavorites(index);
+                                favoriteIcon.name = "starred";
+                            }
+                        }
+                    }
+                }
+
+                Label {
+                    id: stationName
+                    text: name
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                }
+
+                Label {
+                    id: info
+                    visible: miscInfo !== ""
+                    text: miscInfo
+                }
+            }
 
             onClicked: {
                 listView.model.selectStation(stationSelect.type, model.index);
                 stationSelect.stationSelected()
-            }
-
-            MouseArea {
-                anchors { top: parent.top; left: parent.left; leftMargin: units.gu(1); bottom: parent.bottom }
-                width: height
-
-                onClicked: {
-                    if (model.isFavorite) {
-                        listView.model.removeFromFavorites(index);
-                        delegateItem.iconName = "non-starred";
-                    } else {
-                        listView.model.addToFavorites(index);
-                        delegateItem.iconName = "starred";
-                    }
-                }
             }
         }
     }

--- a/src/gui/ubuntu/components/TimePicker.qml
+++ b/src/gui/ubuntu/components/TimePicker.qml
@@ -17,8 +17,8 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.3
-import Ubuntu.Components 1.1
+import QtQuick 2.4
+import Ubuntu.Components 1.2
 import Ubuntu.Components.Popups 1.0
 import Ubuntu.Components.Pickers 1.0
 

--- a/src/gui/ubuntu/main.qml
+++ b/src/gui/ubuntu/main.qml
@@ -17,15 +17,14 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.3
-import Ubuntu.Components 1.1
+import QtQuick 2.4
+import Ubuntu.Components 1.2
 import Fahrplan 1.0
 
 MainView {
     id: appWindow
 
     width: units.gu(40); height: units.gu(71)
-    useDeprecatedToolbar: false
     anchorToKeyboard: true
 
     FahrplanBackend {


### PR DESCRIPTION
This pull request implements the following,

- Updated to ubuntu-sdk-15.04 framework which brings in new animations and features in the Ubuntu SDK. The 15.04 framework will land in OTA-4 which is schedules for the 1st week of June.

- Transitioned to Ubuntu.Components 1.2 and QtQuick 2.4

- Added support for miscinfo in the stationselect page. This should show distances and station types correctly. [Screenshot](https://imgur.com/BWUDBcj) Fixes #204 

- Also improved the timetable results page [Screenshot](https://imgur.com/Y1hp5CD) which includes a partial fix for #207 and also fixed #208.

- With the transition to the Ubuntu.Components 1.2, the listitems used throughout the app have also being converted to the new listitems that have landed in the Ubuntu SDK with the exception of ListItem.ValueSelector.

Note: The following piece of code does not work after the transition to the 15.04 framework. However this code simply connects the pop() to the stationSelected signal. This has been manually added in the stationSelect.qml file to maintain functionality.

```
                    mainStack.currentPage.stationSelected.connect(function() {
                        mainStack.pop();
                    })
```