### PR TITLE
Some improvements to 9292ov.nl

### DIFF
--- a/src/parser/parser_ninetwo.cpp
+++ b/src/parser/parser_ninetwo.cpp
@@ -84,7 +84,9 @@ void ParserNinetwo::findStationsByCoordinates(qreal longitude, qreal latitude)
     QUrl query;
 #endif
     query.addQueryItem("lang", 	"en-GB");
+    query.addQueryItem("type", "station,stop");
     query.addQueryItem("latlong", QString("%1,%2").arg(latitude).arg(longitude));
+    query.addQueryItem("includestation", "true");
     uri.setQuery(query);
 
     sendHttpRequest(uri);

--- a/src/parser/parser_ninetwo.h
+++ b/src/parser/parser_ninetwo.h
@@ -44,6 +44,12 @@ class ParserNinetwo : public ParserAbstract
 
     } lastsearch;
 
+    struct {
+        bool isValid;
+        qreal latitude;
+        qreal longitude;
+    } lastCoordinates;
+
     typedef enum restrictions{
         all=0,
         trainsOnly=1,


### PR DESCRIPTION
I finally got to pushing my changes to 9292ov.nl, done while visiting Amsterdam in April.

Here's a list:

- display train number in journey details and timetable
- search only for stations when searching by coordinates (before, it was also finding pois, streets, etc.)
- display distance to a station when searching by coordinates
- display "On-Time" if realtime status reports it
- display walking duration
- display attributes in journey details
- "not by ferry" rephrased as "All, except ferry"