### PR TITLE
Rename title and button for dialog (Copyright -> License)

### DIFF
--- a/src/gui/ubuntu/AboutPage.qml
+++ b/src/gui/ubuntu/AboutPage.qml
@@ -35,14 +35,14 @@ Page {
         id: dialog
         Dialog {
             id: dialogue
-            title: qsTr("Copyright")
+            title: qsTr("License")
             Flickable {
                 height: units.gu(30)
                 clip: true
-                contentHeight: copyrightText.height
+                contentHeight: licenseText.height
 
                 Label {
-                    id: copyrightText
+                    id: licenseText
                     wrapMode: Text.WordWrap
                     width: parent.width
                     fontSize: "small"
@@ -132,7 +132,7 @@ Page {
                 }
 
                 Button {
-                    text: qsTr("See full copyright")
+                    text: qsTr("View License Terms")
                     anchors.horizontalCenter: parent.horizontalCenter
                     onClicked: PopupUtils.open(dialog)
                 }


### PR DESCRIPTION
As discussed on [Transifex](https://www.transifex.com/leppa/fahrplan/translate/#de/en/41276321), these are the changes to the source code. Untested, but should be okay: I was careful.

After merging the changed resources need to be pushed to Transifex and translated again.

**NOTE:** Line endings are CR/LF (Windows), I left them as they are. Not sure whether converting all sources to Unix line endings wouldn't be better.