### PR TITLE
Migrating from Västtrafik's deprecated API version 1 to OAuth2-based version 2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,8 @@
 **
 ****************************************************************************/
 
+#include <ctime>
+
 #include <QtCore/QTranslator>
 
 #if defined(BUILD_FOR_HARMATTAN) || defined(BUILD_FOR_MAEMO_5) || defined(BUILD_FOR_SYMBIAN) || defined(BUILD_FOR_BLACKBERRY)
@@ -68,6 +70,8 @@ Q_DECL_EXPORT
 #endif
 int main(int argc, char *argv[])
 {
+    qsrand(time(NULL));
+
     #if defined(BUILD_FOR_SAILFISHOS)
         //To support calendar access
         #if defined(BUILD_FOR_OPENREPOS)

--- a/src/parser/parser_abstract.cpp
+++ b/src/parser/parser_abstract.cpp
@@ -96,7 +96,7 @@ void ParserAbstract::cancelRequest()
     }
 }
 
-void ParserAbstract::sendHttpRequest(QUrl url, QByteArray data)
+void ParserAbstract::sendHttpRequest(QUrl url, QByteArray data, const QList<QPair<QByteArray,QByteArray> > &additionalHeaders)
 {
     QNetworkRequest request;
     request.setUrl(url);
@@ -107,6 +107,8 @@ void ParserAbstract::sendHttpRequest(QUrl url, QByteArray data)
     request.setRawHeader("User-Agent", userAgent.toAscii());
 #endif
     request.setRawHeader("Cache-Control", "no-cache");
+    for (QList<QPair<QByteArray,QByteArray> >::ConstIterator it = additionalHeaders.constBegin(); it != additionalHeaders.constEnd(); ++it)
+        request.setRawHeader(it->first, it->second);
     if (!acceptEncoding.isEmpty()) {
         request.setRawHeader("Accept-Encoding", acceptEncoding);
     }

--- a/src/parser/parser_abstract.h
+++ b/src/parser/parser_abstract.h
@@ -86,7 +86,7 @@ protected:
     virtual void parseSearchLaterJourney(QNetworkReply *networkReply);
     virtual void parseSearchEarlierJourney(QNetworkReply *networkReply);
     virtual void parseJourneyDetails(QNetworkReply *networkReply);
-    void sendHttpRequest(QUrl url, QByteArray data);
+    void sendHttpRequest(QUrl url, QByteArray data, const QList<QPair<QByteArray,QByteArray> > &additionalHeaders = QList<QPair<QByteArray,QByteArray> >());
     void sendHttpRequest(QUrl url);
     QVariantMap parseJson(const QByteArray &data) const;
     QByteArray gzipDecompress(QByteArray compressData);

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -109,8 +109,6 @@ void ParserXmlVasttrafikSe::getTimeTableForStation(const Station &currentStation
 
 void ParserXmlVasttrafikSe::findStationsByName(const QString &stationName)
 {
-    qDebug() << "ParserXmlVasttrafikSe::findStationsByName(stationName" << stationName << ")";
-
     if (currentRequestState != FahrplanNS::noneRequest)
         return;
     currentRequestState = FahrplanNS::stationsByNameRequest;
@@ -145,8 +143,6 @@ void ParserXmlVasttrafikSe::findStationsByName(const QString &stationName)
 
 void ParserXmlVasttrafikSe::findStationsByCoordinates(qreal longitude, qreal latitude)
 {
-    qDebug() << "ParserXmlVasttrafikSe::findStationsByCoordinates(longitude=" << longitude << ", latitude=" << latitude << ")";
-
     if (currentRequestState != FahrplanNS::noneRequest)
         return;
     currentRequestState = FahrplanNS::stationsByCoordinatesRequest;
@@ -184,8 +180,6 @@ void ParserXmlVasttrafikSe::findStationsByCoordinates(qreal longitude, qreal lat
 
 void ParserXmlVasttrafikSe::searchJourney(const Station &departureStation, const Station &viaStation, const Station &arrivalStation, const QDateTime &dateTime, ParserAbstract::Mode mode, int trainrestrictions)
 {
-    qDebug() << "ParserXmlVasttrafikSe::searchJourney(departureStation=" << departureStation.name << ", arrivalStation=" << arrivalStation.name << ", viaStation=" << viaStation.name << ", dateTime=" << dateTime.toString() << ", mode=" << mode << ", trainrestrictions=" << trainrestrictions << ")";
-
     if (currentRequestState != FahrplanNS::noneRequest)
         return;
     currentRequestState = FahrplanNS::searchJourneyRequest;
@@ -271,8 +265,6 @@ bool ParserXmlVasttrafikSe::supportsTimeTableDirection()
 
 void ParserXmlVasttrafikSe::parseStationsByName(QNetworkReply *networkReply)
 {
-    qDebug() << "ParserXmlVasttrafikSe::parseStationsByName(networkReply.url()=" << networkReply->url().toString() << ")";
-
     StationsList result;
     QTextStream ts(networkReply->readAll());
     ts.setCodec("UTF-8");
@@ -308,14 +300,11 @@ void ParserXmlVasttrafikSe::parseStationsByName(QNetworkReply *networkReply)
 
 void ParserXmlVasttrafikSe::parseStationsByCoordinates(QNetworkReply *networkReply)
 {
-    qDebug() << "ParserXmlVasttrafikSe::parseStationsByCoordinates(networkReply.url()=" << networkReply->url().toString() << ")";
     parseStationsByName(networkReply);
 }
 
 void ParserXmlVasttrafikSe::parseTimeTable(QNetworkReply *networkReply)
 {
-    qDebug() << "ParserXmlVasttrafikSe::parseTimeTable(networkReply.url()=" << networkReply->url().toString() << ")";
-
     TimetableEntriesList result;
     QTextStream ts(networkReply->readAll());
     ts.setCodec("UTF-8");
@@ -363,8 +352,6 @@ void ParserXmlVasttrafikSe::parseTimeTable(QNetworkReply *networkReply)
 
 void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
 {
-    qDebug() << "ParserXmlVasttrafikSe::parseSearchJourney(networkReply.url()=" << networkReply->url().toString() << ")";
-
     JourneyResultList *journeyResultList = new JourneyResultList();
 
     for (QHash<QString, JourneyDetailResultList *>::Iterator it = cachedJourneyDetails.begin(); it != cachedJourneyDetails.end();) {
@@ -600,7 +587,7 @@ void ParserXmlVasttrafikSe::accessTokenRequestFinished() {
          int expireIn = expiresInRE.cap(1).toInt(&ok);
          if (ok) {
              m_accessTokenExpiration = QDateTime::currentDateTime().addSecs(expireIn - 5);
-             qDebug() << "Got an access token" << m_accessToken << "to expire in" << expireIn << "sec";
+             qDebug() << "Got access token" << m_accessToken << "which expires in" << expireIn << "sec";
 
              if (currentRequestState == FahrplanNS::stationsByNameRequest && m_stationByNameParameters.isValid) {
                  currentRequestState = FahrplanNS::noneRequest; ///< to make a check in findStationsByName(..) work

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -44,6 +44,8 @@ ParserXmlVasttrafikSe::ParserXmlVasttrafikSe(QObject *parent)
 {
     m_searchJourneyParameters.isValid = false;
     m_timeTableForStationParameters.isValid = false;
+    m_stationByNameParameters.isValid = false;
+    m_stationByCoordinatesParameters.isValid = false;
 }
 
 

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -41,6 +41,7 @@ QHash<QString, JourneyDetailResultList *> cachedJourneyDetails;
 #define getAttribute(node, key) (node.attributes().namedItem(key).toAttr().value())
 
 const QString ParserXmlVasttrafikSe::baseRestUrl = QLatin1String("https://api.vasttrafik.se/bin/rest.exe/v2/");
+const char *ParserXmlVasttrafikSe::consumerCredentials = "ZHhONXJGdUpOZ1NfQjltc29zZlRuYTBwelpjYTpPMDVsNEhTNGdieU5KdGY4a29MRmdCZ1g0WUFh";
 
 ParserXmlVasttrafikSe::ParserXmlVasttrafikSe(QObject *parent)
     : ParserAbstract(parent)
@@ -574,7 +575,9 @@ void ParserXmlVasttrafikSe::requestNewAccessToken() {
     qDebug() << "Requesting new access token for device" << m_deviceId;
     QNetworkRequest request(QUrl(QLatin1String("https://api.vasttrafik.se/token")));
     request.setHeader(QNetworkRequest::ContentTypeHeader, QLatin1String("application/x-www-form-urlencoded"));
-    request.setRawHeader("Authorization", "Basic SWlUU1dmY0dYdVFId2FqMXYyYktCTXZvOFNNYTpyN0pvMHJDNHBTbEhUUHlDZm1DNUxwMmVWd29h");
+    QByteArray authorizationData("Basic ");
+    authorizationData.append(consumerCredentials);
+    request.setRawHeader("Authorization", authorizationData);
     QByteArray postData("grant_type=client_credentials&scope=device_");
 #if defined(BUILD_FOR_QT5)
     postData.append(m_deviceId.toLatin1());

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -224,7 +224,7 @@ void ParserXmlVasttrafikSe::parseStationsByName(QNetworkReply *networkReply)
     QDomDocument doc("result");
     if (doc.setContent(xmlRawtext, false)) {
         QDomNodeList locationList = doc.elementsByTagName("StopLocation");
-        for (unsigned int i = 0; i < locationList.length(); ++i) {
+        for (int i = 0; i < locationList.length(); ++i) {
             QDomNode locationNode = locationList.item(i);
 
             Station item;
@@ -269,7 +269,7 @@ void ParserXmlVasttrafikSe::parseTimeTable(QNetworkReply *networkReply)
             nodeList = doc.elementsByTagName("Arrival");
             isArrival = true;
         }
-        for (unsigned int i = 0; i < nodeList.length(); ++i) {
+        for (int i = 0; i < nodeList.length(); ++i) {
             QDomNode node = nodeList.item(i);
             TimetableEntry item;
 
@@ -328,7 +328,7 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
     QDomDocument doc("result");
     if (doc.setContent(xmlRawtext, false)) {
         QDomNodeList tripNodeList = doc.elementsByTagName("Trip");
-        for (unsigned int i = 0; i < tripNodeList.length(); ++i) {
+        for (int i = 0; i < tripNodeList.length(); ++i) {
             JourneyResultItem *jritem = new JourneyResultItem();
             JourneyDetailResultList *detailsList = new JourneyDetailResultList();
 
@@ -340,7 +340,7 @@ void ParserXmlVasttrafikSe::parseSearchJourney(QNetworkReply *networkReply)
             int numStops = 0;
             QStringList trainTypes;
             int tripRtStatus = TRIP_RTDATA_NONE;
-            for (unsigned int j = 0; j < legNodeList.length(); ++j) {
+            for (int j = 0; j < legNodeList.length(); ++j) {
                 QDomNode legNode = legNodeList.item(j);
                 QDomNode originNode = legNode.namedItem("Origin");
                 QDomNode destinationNode = legNode.namedItem("Destination");

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -237,6 +237,7 @@ void ParserXmlVasttrafikSe::parseStationsByName(QNetworkReply *networkReply)
         }
     }
 
+    /** FIXME is this dead code, as ...isValid was never set to true before the changes for API v2
     if (m_timeTableForStationParameters.isValid) {
         getTimeTableForStation(m_timeTableForStationParameters.currentStation, m_timeTableForStationParameters.directionStation, m_timeTableForStationParameters.dateTime, m_timeTableForStationParameters.mode, m_timeTableForStationParameters.trainrestrictions);
     } else if (m_searchJourneyParameters.isValid) {
@@ -244,6 +245,8 @@ void ParserXmlVasttrafikSe::parseStationsByName(QNetworkReply *networkReply)
     } else {
         emit stationsResult(result);
     }
+    */
+    emit stationsResult(result);
 }
 
 void ParserXmlVasttrafikSe::parseStationsByCoordinates(QNetworkReply *networkReply)

--- a/src/parser/parser_xmlvasttrafikse.h
+++ b/src/parser/parser_xmlvasttrafikse.h
@@ -77,6 +77,16 @@ private:
         int trainrestrictions;
     } m_timeTableForStationParameters;
 
+    struct {
+        bool isValid;
+        QString stationName;
+    } m_stationByNameParameters;
+
+    struct {
+        bool isValid;
+        qreal longitude, latitude;
+    } m_stationByCoordinatesParameters;
+
     const QString apiKey;
     const QString baseRestUrl;
 

--- a/src/parser/parser_xmlvasttrafikse.h
+++ b/src/parser/parser_xmlvasttrafikse.h
@@ -55,6 +55,8 @@ protected:
     virtual void parseTimeTable(QNetworkReply *networkReply);
     virtual void parseSearchJourney(QNetworkReply *networkReply);
 
+    void sendHttpRequestWithBearer(const QUrl &uri);
+
 private:
     static const qlonglong TRIP_RTDATA_NONE;
     static const qlonglong TRIP_RTDATA_ONTIME;
@@ -89,8 +91,7 @@ private:
         qreal longitude, latitude;
     } m_stationByCoordinatesParameters;
 
-    const QString apiKey;
-    const QString baseRestUrl;
+    static const QString baseRestUrl;
     QNetworkAccessManager *m_nam;
     QDateTime m_accessTokenExpiration;
     QString m_accessToken, m_deviceId;

--- a/src/parser/parser_xmlvasttrafikse.h
+++ b/src/parser/parser_xmlvasttrafikse.h
@@ -92,6 +92,7 @@ private:
     } m_stationByCoordinatesParameters;
 
     static const QString baseRestUrl;
+    static const char *consumerCredentials;
     QNetworkAccessManager *m_nam;
     QDateTime m_accessTokenExpiration;
     QString m_accessToken, m_deviceId;

--- a/src/parser/parser_xmlvasttrafikse.h
+++ b/src/parser/parser_xmlvasttrafikse.h
@@ -28,6 +28,8 @@ class ParserXmlVasttrafikSe : public ParserAbstract
 
 public:
     explicit ParserXmlVasttrafikSe(QObject *parent = 0);
+    ~ParserXmlVasttrafikSe();
+
     static QString getName() { return QString("%1 (vasttrafik.se)").arg(tr("Sweden")); }
     virtual QString name() { return getName(); }
     virtual QString shortName() { return "vasttrafik.se"; }
@@ -89,10 +91,18 @@ private:
 
     const QString apiKey;
     const QString baseRestUrl;
+    QNetworkAccessManager *m_nam;
+    QDateTime m_accessTokenExpiration;
+    QString m_accessToken, m_deviceId;
 
     QDateTime m_earliestArrival, m_latestResultDeparture;
 
     inline QString i18nConnectionType(const QString &swedishText) const;
+
+    void requestNewAccessToken();
+
+private slots:
+    void accessTokenRequestFinished();
 };
 
 #endif // PARSER_XMLVASTTRAFIKSE_H


### PR DESCRIPTION
In late 2015, [Västtrafik](https://developer.vasttrafik.se/), the public transportation provider in West Sweden, migrated its public API to a new version. The major difference between version 1 and 2 is the authentication: Whereas version 1 required clients to have an API key (per application, given to registered developers) to make RESTful requests, the new API uses OAuth2 in the variant "client credentials". An additional network request is necessary to retrieve a per-device, time-limited "access token" from an authentication server (requires sending an application-specific "consumer key" and "consumer secret" given to registered developers). This access token is passed along in an HTTP authorization header using the "Bearer" keyword when querying for stations, time tables, etc.
The actual request for stations or journeys doesn't seem to have changed at all, so no changed necessary there.

I have tested this code in the SailfishOS SDK, which is Qt5-based. I tried to keep the code compatible to Qt4, but I have made no tests in this respect. Also, no tests if the code works on other platforms like Ubuntu Touch or BlackBerry.