### PR TITLE
Use Ubuntu.Components 1.3 features

### DIFF
--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -358,6 +358,10 @@ win32|unix:!simulator:!maemo5:!contains(MEEGO_EDITION,harmattan):!symbian:!exist
 symbian|simulator {
     RESOURCES += symbian_res.qrc
 
+    # Symbian does not like gauss-kruger as lib so we add it as sources too
+    SOURCES += $$PWD/3rdparty/gauss-kruger-cpp/gausskruger.cpp
+    HEADERS += $$PWD/3rdparty/gauss-kruger-cpp/gausskruger.h
+
     OTHER_FILES += \
         src/gui/symbian/main.qml \
         src/gui/symbian/components/SubTitleButton.qml \

--- a/qtc_packaging/debian_harmattan/changelog
+++ b/qtc_packaging/debian_harmattan/changelog
@@ -1,3 +1,8 @@
+fahrplan2 (2.0.27-1) unstable; urgency=low
+  * Charset fix for resrobot.se
+  
+ -- smurfy <maemo@smurfy.de>  Mon, 21 March 2016 20:00:00 +0100
+
 fahrplan2 (2.0.27) unstable; urgency=low
   * Save trainrestrictions to settings
   * Backends are now sorted

--- a/src/gui/sailfishos/delegates/JourneyDetailsStationDelegate.qml
+++ b/src/gui/sailfishos/delegates/JourneyDetailsStationDelegate.qml
@@ -35,7 +35,7 @@ Item {
             top: parent.top
             topMargin: 0
             left: parent.left
-            leftMargin: (timeWidth ? timeWidth : 70) + Theme.iconSizeSmall/2 - width/2
+            leftMargin: (timeWidth ? timeWidth : Theme.paddingLarge * 3) + Theme.iconSizeSmall/2 - width/2
         }
         gradient: Gradient {
             GradientStop {
@@ -76,7 +76,7 @@ Item {
         radius: Theme.iconSizeSmall/2
         anchors {
             left: parent.left
-            leftMargin: timeWidth ? timeWidth : 70
+            leftMargin: timeWidth ? timeWidth : Theme.paddingLarge * 3
             verticalCenter: parent.verticalCenter
         }
 

--- a/src/gui/sailfishos/delegates/JourneyDetailsTrainDelegate.qml
+++ b/src/gui/sailfishos/delegates/JourneyDetailsTrainDelegate.qml
@@ -39,7 +39,7 @@ Item {
         color: Theme.highlightColor
         anchors {
             left: parent.left
-            leftMargin: (timeWidth ? timeWidth : 70) + Theme.iconSizeSmall/2 - width/2
+            leftMargin: (timeWidth ? timeWidth : Theme.paddingLarge * 3) + Theme.iconSizeSmall/2 - width/2
         }
     }
 

--- a/src/gui/sailfishos/pages/JourneyDetailsResultsPage.qml
+++ b/src/gui/sailfishos/pages/JourneyDetailsResultsPage.qml
@@ -70,7 +70,7 @@ Page {
                         left: parent.left
                         leftMargin: Theme.paddingMedium
                         top: parent.top
-                        topMargin: 80
+                        topMargin: Theme.paddingLarge * 3
                     }
                     width: ((parent.width / 3) * 2) - 20
                     wrapMode: Text.WordWrap
@@ -84,7 +84,7 @@ Page {
                         rightMargin: Theme.paddingMedium
                         left: lbljourneyDate.right
                         top: parent.top
-                        topMargin: 80
+                        topMargin: Theme.paddingLarge * 3
                     }
                     width: (parent.width / 3) - 20
                     horizontalAlignment: Text.AlignRight

--- a/src/gui/sailfishos/pages/JourneyResultsPage.qml
+++ b/src/gui/sailfishos/pages/JourneyResultsPage.qml
@@ -69,7 +69,7 @@ Page {
                     color: Theme.secondaryColor
                     anchors {
                         top: parent.top
-                        topMargin: 80
+                        topMargin: Theme.paddingLarge * 3
                         right: parent.right
                         rightMargin: Theme.paddingMedium
                     }

--- a/src/gui/ubuntu/AboutPage.qml
+++ b/src/gui/ubuntu/AboutPage.qml
@@ -31,7 +31,7 @@ Page {
         flickable: tabView
         extension: Sections {
             id: aboutPageSections
-            anchors { left: parent.left; leftMargin: units.gu(2); bottom: parent.bottom }
+            anchors { left: parent.left; bottom: parent.bottom }
             model: [qsTr("About"), qsTr("Credits"), qsTr("Support")]
         }
     }
@@ -72,11 +72,11 @@ Page {
 
             Column {
                 spacing: units.gu(4)
-                anchors.centerIn: parent
+                anchors { top: parent.top; topMargin: units.gu(2) }
                 width: parent.width > units.gu(50) ? units.gu(50) : parent.width
 
                 UbuntuShape {
-                    width: parent.width / 2
+                    width: parent.width / 2.5
                     height: width
                     radius: "medium"
                     anchors.horizontalCenter: parent.horizontalCenter

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -322,12 +322,6 @@ Page {
                     id: selectedBackendListView
                     delegate: ListItems.Standard {
                         text: name
-
-                        // FIXME: This is a workaround for the theme not being context sensitive. I.e. the
-                        // ListItems don't know that they are sitting in a themed Popover where the color
-                        // needs to be inverted.
-                        __foregroundColor: Theme.palette.selected.backgroundText
-
                         onClicked: {
                             fahrplanBackend.setParser(fahrplanBackend.backends.getParserIdForItemIndex(index))
                             PopupUtils.close(selectBackendDialog)
@@ -356,11 +350,6 @@ Page {
                 model: fahrplanBackend.trainrestrictions
                 delegate: ListItems.Standard {
                     text: modelData
-                    // FIXME: This is a workaround for the theme not being context sensitive. I.e. the
-                    // ListItems don't know that they are sitting in a themed Popover where the color
-                    // needs to be inverted.
-                    __foregroundColor: Theme.palette.selected.backgroundText
-
                     onClicked: {
                         fahrplanBackend.setTrainrestriction(index)
                         PopupUtils.close(selectTrainrestrictionsDialog)

--- a/src/gui/ubuntu/MainPage.qml
+++ b/src/gui/ubuntu/MainPage.qml
@@ -97,10 +97,6 @@ Page {
         anchors.fill: parent
         contentHeight: buttons.height
 
-        onMovementStarted: {
-            flickable.clip = true;
-        }
-
         Column {
             id: buttons
 

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -327,7 +327,11 @@ void ParserResRobot::doSearchJourney(QUrl query)
 
 void ParserResRobot::parseTimeTable(QNetworkReply *networkReply)
 {
+#if defined(BUILD_FOR_HARMATTAN)
+    QByteArray allData = QString::fromUtf8(networkReply->readAll()).toAscii();
+#else
     QByteArray allData = networkReply->readAll();
+#endif
     qDebug() << "Reply:\n" << allData;
 
     QVariantMap doc = parseJson(allData);
@@ -389,7 +393,11 @@ void ParserResRobot::parseTimeTable(QNetworkReply *networkReply)
 
 void ParserResRobot::parseStationsByName(QNetworkReply *networkReply)
 {
+#if defined(BUILD_FOR_HARMATTAN)
+    QByteArray allData = QString::fromUtf8(networkReply->readAll()).toAscii();
+#else
     QByteArray allData = networkReply->readAll();
+#endif
     qDebug() << "Reply:\n" << allData;
 
     QVariantMap doc = parseJson(allData);
@@ -414,7 +422,11 @@ void ParserResRobot::parseStationsByName(QNetworkReply *networkReply)
 
 void ParserResRobot::parseStationsByCoordinates(QNetworkReply *networkReply)
 {
+#if defined(BUILD_FOR_HARMATTAN)
+    QByteArray allData = QString::fromUtf8(networkReply->readAll()).toAscii();
+#else
     QByteArray allData = networkReply->readAll();
+#endif
     qDebug() << "Reply:\n" << allData;
 
     QVariantMap doc = parseJson(allData);
@@ -440,7 +452,11 @@ void ParserResRobot::parseStationsByCoordinates(QNetworkReply *networkReply)
 
 void ParserResRobot::parseSearchJourney(QNetworkReply *networkReply)
 {
+#if defined(BUILD_FOR_HARMATTAN)
+    QByteArray allData = QString::fromUtf8(networkReply->readAll()).toAscii();
+#else
     QByteArray allData = networkReply->readAll();
+#endif
     qDebug() << "Reply:\n" << allData;
 
     QVariantMap doc = parseJson(allData);


### PR DESCRIPTION
Ubuntu.Components 1.3 brings a host of new components that help with list item performance and more adaptable page headers. This pull request implements the following,
- Migrated CustomListItem to **ListItemLayout**
- Switch JourneyResultsPage over to **ListItemLayout**
- Replaced fontSize with **textSize** property introduced in UC 1.3 (_fontSize used string comparison which was expensive_)
- Migrated to **PageHeaders** which is a lot more customizable and a prerequisite for using AdaptivePageLayouts.
