### PR TITLE
Fixes for Västtrafik (Sweden)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
 
 before_install:
   - if [ "$CXX" = "g++" ]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; fi
-  - if [ "$QT_BASE" = "48" ]; then sudo add-apt-repository ppa:beineri/opt-qt487 -y; fi
-  - if [ "$QT_BASE" = "52" ]; then sudo add-apt-repository ppa:beineri/opt-qt521 -y; fi
+  - if [ "$QT_BASE" = "48" ]; then sudo add-apt-repository ppa:beineri/opt-qt487-trusty -y; fi
+  - if [ "$QT_BASE" = "52" ]; then sudo add-apt-repository ppa:beineri/opt-qt521-trusty -y; fi
 
 install:
   - sudo apt-get update -qq

--- a/bar-descriptor.xml
+++ b/bar-descriptor.xml
@@ -5,7 +5,7 @@
     <publisher>Oleksii Serdiuk</publisher>
     <authorId>gYAAgFEzqeGb8kgSIn13NIOmc_c</authorId>
     <name>Fahrplan</name>
-    <versionNumber>2.0.28</versionNumber>
+    <versionNumber>2.0.29</versionNumber>
     <buildId>0</buildId>
     <description>A Journey planner/Railway Time table for many train lines in Europe and Australia</description>
     <initialWindow>

--- a/data/bb10/ChangeLog.md
+++ b/data/bb10/ChangeLog.md
@@ -1,6 +1,11 @@
 BlackBerry World ChangeLog
 ==========================
 
+2.0.29
+------
+
+- Updated matka.fi API
+
 2.0.28
 ------
 

--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -1,5 +1,5 @@
 # Define Version
-VERSION = 2.0.28
+VERSION = 2.0.29
 
 # Switch for jolla to separate harbour and openrepo version
 openrepos {

--- a/qtc_packaging/debian_fremantle/changelog
+++ b/qtc_packaging/debian_fremantle/changelog
@@ -1,3 +1,8 @@
+fahrplan2 (2.0.29) unstable; urgency=low
+  * Updated Updated matka.fi API
+  
+ -- smurfy <maemo@smurfy.de>  Wed, 08 March 2017 20:00:00 +0100
+ 
 fahrplan2 (2.0.28) unstable; urgency=low
   * Fixes 9292ov.nl
   * Updated ResRobot API to v2

--- a/qtc_packaging/debian_harmattan/changelog
+++ b/qtc_packaging/debian_harmattan/changelog
@@ -1,3 +1,8 @@
+fahrplan2 (2.0.29) unstable; urgency=low
+  * Updated Updated matka.fi API
+  
+ -- smurfy <maemo@smurfy.de>  Wed, 08 March 2017 20:00:00 +0100
+ 
 fahrplan2 (2.0.28) unstable; urgency=low
   * Fixes 9292ov.nl
   * Updated ResRobot API to v2

--- a/qtc_packaging/ubuntu/manifest.json
+++ b/qtc_packaging/ubuntu/manifest.json
@@ -11,5 +11,5 @@
     "maintainer": "Michael Zanetti <michael_zanetti@gmx.net>",
     "name": "com.ubuntu.developer.mzanetti.fahrplan2",
     "title": "Fahrplan",
-    "version": "2.0.28"
+    "version": "2.0.29"
 }

--- a/rpm/harbour-fahrplan2.yaml
+++ b/rpm/harbour-fahrplan2.yaml
@@ -1,6 +1,6 @@
 Name: harbour-fahrplan2
 Summary: Public transportation application
-Version: 2.0.28
+Version: 2.0.29
 Release: 1
 Group: Location/Location Adaptation
 License: GPL

--- a/src/gui/about.js
+++ b/src/gui/about.js
@@ -19,7 +19,7 @@
 
 .pragma library
 
-var copyright = "(C) 2008-2016 smurfy (maemo@smurfy.de)";
+var copyright = "(C) 2008-2017 smurfy (maemo@smurfy.de)";
 
 var license = "<p>This program is free software; you can redistribute it and/or " +
         "modify it under the terms of the GNU General Public License " +

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -576,7 +576,7 @@ void ParserXmlVasttrafikSe::requestNewAccessToken() {
 }
 
 void ParserXmlVasttrafikSe::accessTokenRequestFinished() {
-     static const QRegExp accessTokenRE(QLatin1String("\"access_token\":\"([0-9a-f]+)"));
+     static const QRegExp accessTokenRE(QLatin1String("\"access_token\":\"([^\"]+)"));
      static const QRegExp expiresInRE(QLatin1String("\"expires_in\":([1-9][0-9]*)"));
 
      QNetworkReply *reply = static_cast<QNetworkReply *>(sender());

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -591,7 +591,7 @@ void ParserXmlVasttrafikSe::accessTokenRequestFinished() {
      if (reply->error() == QNetworkReply::NoError && accessTokenRE.indexIn(rawText) > 0 && expiresInRE.indexIn(rawText) > 0) {
          m_accessToken = accessTokenRE.cap(1);
          int expireIn = expiresInRE.cap(1).toInt(&ok);
-         if (ok) {
+         if (ok && expireIn > 0) {
              m_accessTokenExpiration = QDateTime::currentDateTime().addSecs(expireIn - 5);
              qDebug() << "Got access token" << m_accessToken << "which expires in" << expireIn << "sec";
 

--- a/src/parser/parser_xmlvasttrafikse.cpp
+++ b/src/parser/parser_xmlvasttrafikse.cpp
@@ -608,11 +608,13 @@ void ParserXmlVasttrafikSe::accessTokenRequestFinished() {
                  currentRequestState = FahrplanNS::noneRequest; ///< to make a check in searchJourney(..) work
                  searchJourney(m_searchJourneyParameters.departureStation, m_searchJourneyParameters.viaStation, m_searchJourneyParameters.arrivalStation,m_searchJourneyParameters.dateTime, m_searchJourneyParameters.mode, m_searchJourneyParameters.trainrestrictions);
              }
-         }
-     }
+         } else
+             qWarning() << "Failed to extract expiration time from this: " << expiresInRE.cap(1);
+     } else
+         qWarning() << "Request for access token failed: " << reply->errorString();
 
      if (!ok) {
-         qWarning() << "Failed to extract access token from this data:" << rawText;
+         qWarning() << "Failed to extract access token from this data:" << rawText.left(256);
          m_accessTokenExpiration.setDate(QDate(2000, 1, 1));
      }
- }
+}


### PR DESCRIPTION
This pull request contains four commits that improve Västtrafik support in Fahrplan.
Commit 78e7d10 is most important as it corrects the regular expression extracting the access token from the OAuth authentication. Without it, Västtrafik search does not work.
The other three commits are rather small, the only noteworthy change is that of the deviceID generation being changed from a combination of application name, random numbers, and other things to a hash aggregating the current device's network interfaces' hardware names. This allows to identify application instances across restarts. The device identification can be used to get usage statistics from Västtrafik's developer platform.