### PR TITLE
Allow empty replies from Resrobot server

### DIFF
--- a/src/parser/parser_abstract.cpp
+++ b/src/parser/parser_abstract.cpp
@@ -145,11 +145,11 @@ void ParserAbstract::sendHttpRequest(QUrl url, QByteArray data, const QList<QPai
     connect(lastRequest, SIGNAL(downloadProgress(qint64,qint64)), this, SLOT(networkReplyDownloadProgress(qint64,qint64)));
 }
 
-QVariantMap ParserAbstract::parseJson(const QByteArray &json) const
+QVariant ParserAbstract::parseJson(const QByteArray &json) const
 {
-    QVariantMap doc;
+    QVariant doc;
 #ifdef BUILD_FOR_QT5
-    doc = QJsonDocument::fromJson(json).toVariant().toMap();
+    doc = QJsonDocument::fromJson(json).toVariant();
 #else
     QString utf8(QString::fromUtf8(json));
 
@@ -160,7 +160,7 @@ QVariantMap ParserAbstract::parseJson(const QByteArray &json) const
         return doc;
 
     QScriptEngine *engine = new QScriptEngine();
-    doc = engine->evaluate("(" + utf8 + ")").toVariant().toMap();
+    doc = engine->evaluate("(" + utf8 + ")").toVariant();
     delete engine;
 #endif
 
@@ -168,9 +168,9 @@ QVariantMap ParserAbstract::parseJson(const QByteArray &json) const
 }
 
 #ifdef BUILD_FOR_QT5
-QByteArray ParserAbstract::serializeToJson(const QVariantMap& doc) const
+QByteArray ParserAbstract::serializeToJson(const QVariant& doc) const
 {
-    return QJsonDocument(QJsonObject::fromVariantMap(doc)).toJson(QJsonDocument::Indented);
+    return QJsonDocument::fromVariant(doc).toJson(QJsonDocument::Indented);
 }
 #else
 QByteArray toJson(const QVariant& value)
@@ -212,7 +212,7 @@ QByteArray toJson(const QVariant& value)
     }
 }
 
-QByteArray ParserAbstract::serializeToJson(const QVariantMap& doc) const
+QByteArray ParserAbstract::serializeToJson(const QVariant& doc) const
 {
     return toJson(doc);
 }

--- a/src/parser/parser_abstract.h
+++ b/src/parser/parser_abstract.h
@@ -92,8 +92,8 @@ protected:
     virtual void parseJourneyDetails(QNetworkReply *networkReply);
     void sendHttpRequest(QUrl url, QByteArray data, const QList<QPair<QByteArray,QByteArray> > &additionalHeaders = QList<QPair<QByteArray,QByteArray> >());
     void sendHttpRequest(QUrl url);
-    QVariantMap parseJson(const QByteArray &data) const;
-    QByteArray serializeToJson(const QVariantMap &doc) const;
+    QVariant parseJson(const QByteArray &data) const;
+    QByteArray serializeToJson(const QVariant &doc) const;
     QByteArray gzipDecompress(QByteArray compressData);
 
 #ifdef BUILD_FOR_UBUNTU

--- a/src/parser/parser_finland_matka.cpp
+++ b/src/parser/parser_finland_matka.cpp
@@ -147,7 +147,7 @@ void ParserFinlandMatka::parseStationsByName(QNetworkReply *networkReply)
     }
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
@@ -299,7 +299,7 @@ void ParserFinlandMatka::parseTimeTable(QNetworkReply *networkReply)
     }
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
@@ -664,7 +664,7 @@ void ParserFinlandMatka::parseSearchJourney(QNetworkReply *networkReply)
     }
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;

--- a/src/parser/parser_ninetwo.cpp
+++ b/src/parser/parser_ninetwo.cpp
@@ -209,7 +209,7 @@ void ParserNinetwo::parseTimeTable(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "REPLY:>>>>>>>>>>>>\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
@@ -287,7 +287,7 @@ void ParserNinetwo::parseStationsByName(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "REPLY:>>>>>>>>>>>>\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
@@ -346,7 +346,7 @@ void ParserNinetwo::parseSearchJourney(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
     qDebug() << "REPLY:>>>>>>>>>>>>\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -376,17 +376,17 @@ void ParserResRobot::parseTimeTable(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData).toMap();
-    if (doc.isEmpty()) {
+    QVariant reply = parseJson(allData);
+    if (!reply.isValid()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
     }
-
+    QVariantMap replyMap = reply.toMap();
     QVariantList departures;
     if (timetableSearchMode == Arrival)
-        departures = doc.value("Arrival").toList();
+        departures = replyMap.value("Arrival").toList();
     else
-        departures = doc.value("Departure").toList();
+        departures = replyMap.value("Departure").toList();
     TimetableEntriesList timetable;
     foreach (QVariant departureData, departures) {
         TimetableEntry resultItem;
@@ -439,12 +439,13 @@ void ParserResRobot::parseStationsByName(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData).toMap();
-    if (doc.isEmpty()) {
+    QVariant reply = parseJson(allData);
+    if (!reply.isValid()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
     }
-    QVariantList stations = doc.value("StopLocation").toList();
+    QVariantMap replyMap = reply.toMap();
+    QVariantList stations = replyMap.value("StopLocation").toList();
     StationsList result;
     foreach (QVariant stationData, stations) {
         const QVariantMap& station = stationData.toMap();
@@ -464,13 +465,13 @@ void ParserResRobot::parseStationsByCoordinates(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData).toMap();
-    if (doc.isEmpty()) {
+    QVariant reply = parseJson(allData);
+    if (!reply.isValid()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
     }
-
-    QVariantList stations = doc.value("StopLocation").toList();
+    QVariantMap replyMap = reply.toMap();
+    QVariantList stations = replyMap.value("StopLocation").toList();
     StationsList result;
     foreach (QVariant stationData, stations) {
         const QVariantMap& station = stationData.toMap();
@@ -490,15 +491,15 @@ void ParserResRobot::parseSearchJourney(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData).toMap();
-    if (doc.isEmpty()) {
+    QVariant reply = parseJson(allData);
+    if (!reply.isValid()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
     }
-
-    searchEarlierReference = doc.value("scrB").toString();
-    searchLaterReference = doc.value("scrF").toString();
-    QVariantList journeyListData = doc.value("Trip").toList();
+    QVariantMap replyMap = reply.toMap();
+    searchEarlierReference = replyMap.value("scrB").toString();
+    searchLaterReference = replyMap.value("scrF").toString();
+    QVariantList journeyListData = replyMap.value("Trip").toList();
 
     cachedResults.clear();
 

--- a/src/parser/parser_resrobot.cpp
+++ b/src/parser/parser_resrobot.cpp
@@ -376,7 +376,7 @@ void ParserResRobot::parseTimeTable(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
@@ -439,7 +439,7 @@ void ParserResRobot::parseStationsByName(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
@@ -464,7 +464,7 @@ void ParserResRobot::parseStationsByCoordinates(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;
@@ -490,7 +490,7 @@ void ParserResRobot::parseSearchJourney(QNetworkReply *networkReply)
     QByteArray allData = networkReply->readAll();
 //    qDebug() << "Reply:\n" << allData;
 
-    QVariantMap doc = parseJson(allData);
+    QVariantMap doc = parseJson(allData).toMap();
     if (doc.isEmpty()) {
         emit errorOccured(tr("Cannot parse reply from the server"));
         return;


### PR DESCRIPTION
Sometimes, the server reply can be empty and still valid. This is for example the case with time table replies when there are no departures from a station (or at least not any departures matching the selected direction).

In order to do this change, I had to modify the signature of `parseJson()` to return a `QVariant` instead of a `QVariantMap`, so callers can check if the parsing succeeded in a better way than looking whether the returned map is empty. For symmetry, I also changed `serializeToJson()` correspondingly.

The other two backends using `parseJson()` (Matka and NineTwo) have been left with unchanged behaviour, since I'd rather not fix them unless broken.

Should solve #267.

@smurfy Please review.