### PR TITLE
Add mising build dependencies

### DIFF
--- a/rpm/harbour-fahrplan2.yaml
+++ b/rpm/harbour-fahrplan2.yaml
@@ -15,11 +15,17 @@ PkgConfigBR:
 - Qt5Quick
 - Qt5Qml
 - Qt5Core
+- Qt5Network
+- Qt5Xml
+- Qt5Concurrent
+- sailfishapp
+
 Requires:
 - sailfishsilica-qt5 >= 0.10.9
+
 Files:
 - '%defattr(644,root,root,-)'
 - '%attr(655,-,-) %{_bindir}'
 - '%{_datadir}/icons/hicolor/86x86/apps/%{name}.png'
 - '%{_datadir}/applications/%{name}.desktop'
-PkgBR: [qt5-qtdeclarative-import-positioning, qt5-qtpositioning-devel]
+PkgBR: [qt5-qtdeclarative-import-positioning, qt5-qtpositioning-devel, qt5-qttools-linguist]


### PR DESCRIPTION
Those where probably missing as they are already installed in the sdk
but not during clean build on sailfish buildservice.