### PR TITLE
Update URLs for OEBB parser to use HTTPS + switch to XML queries (from HAFAS binary)

### DIFF
--- a/src/parser/parser_xmloebbat.cpp
+++ b/src/parser/parser_xmloebbat.cpp
@@ -22,10 +22,10 @@
 ParserXmlOebbAt::ParserXmlOebbAt(QObject *parent)
     : ParserHafasBinary(parent)
 {
-    baseXmlUrl = "http://fahrplan.oebb.at/bin/query.exe";
-    baseSTTableUrl = "http://fahrplan.oebb.at/bin/stboard.exe/en";
-    baseUrl = "http://fahrplan.oebb.at/bin/query.exe";
-    baseBinaryUrl = "http://fahrplan.oebb.at/bin/query.exe/en";
+    baseXmlUrl = "https://fahrplan.oebb.at/bin/query.exe";
+    baseSTTableUrl = "https://fahrplan.oebb.at/bin/stboard.exe/en";
+    baseUrl = "https://fahrplan.oebb.at/bin/query.exe";
+    baseBinaryUrl = "https://fahrplan.oebb.at/bin/query.exe/en";
     STTableMode = 1;
 }
 

--- a/src/parser/parser_xmloebbat.cpp
+++ b/src/parser/parser_xmloebbat.cpp
@@ -20,12 +20,11 @@
 #include "parser_xmloebbat.h"
 
 ParserXmlOebbAt::ParserXmlOebbAt(QObject *parent)
-    : ParserHafasBinary(parent)
+    : ParserHafasXml(parent)
 {
     baseXmlUrl = "https://fahrplan.oebb.at/bin/query.exe";
     baseSTTableUrl = "https://fahrplan.oebb.at/bin/stboard.exe/en";
     baseUrl = "https://fahrplan.oebb.at/bin/query.exe";
-    baseBinaryUrl = "https://fahrplan.oebb.at/bin/query.exe/en";
     STTableMode = 1;
 }
 

--- a/src/parser/parser_xmloebbat.h
+++ b/src/parser/parser_xmloebbat.h
@@ -22,7 +22,7 @@
 
 #include "parser_hafasbinary.h"
 
-class ParserXmlOebbAt: public ParserHafasBinary
+class ParserXmlOebbAt: public ParserHafasXml
 {
     Q_OBJECT
 


### PR DESCRIPTION
The website made https mandatory now. With the old http URLs the queries don't work any more.
Fixes https://github.com/smurfy/fahrplan/issues/283

Edit:
Furthermore I recently got some connections of `connectionDetailsVersion != 1` and couldn't find a source online on how to handle this issue. As a workaround the second commit in this PR changes ÖBB to use XML queries.